### PR TITLE
Move architecture specific pieces into .h files

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
@@ -1,0 +1,101 @@
+#if defined(ARDUINO_ARCH_ESP32)
+#ifndef __ESP32_H__
+
+#include <EEPROM.h>
+#define EEPROM_SIZE 1024 //ESP32 emulates EEPROM in non-volatile storage (external flash IC). Max is 508k.
+
+void esp32BeginBoard()
+{
+  //Lower power boards
+  pin_cs = 15;
+  pin_dio0 = 26; //aka A0
+  pin_dio1 = 25; //aka A1
+  pin_rst = 32;
+
+  pin_trigger = 13;
+
+  pin_trainButton = 0;
+
+  //Debug
+  pinMode(pin_trigger, OUTPUT);
+  digitalWrite(pin_trigger, HIGH);
+
+  strcpy(platformPrefix, "ESP32 100mW");
+}
+
+void esp32BeginSerial(uint16_t serialSpeed)
+{
+#if defined(ENABLE_DEVELOPER)
+  //Wait for serial to come online for debug printing
+  delay(500);
+#endif  //ENABLE_DEVELOPER
+}
+
+void esp32BeginWDT()
+{
+  petTimeoutHalf = 1000 / 2;
+}
+
+void esp32EepromBegin()
+{
+  EEPROM.begin(EEPROM_SIZE);
+}
+
+void esp32EepromCommit()
+{
+  EEPROM.commit();
+}
+
+//Perform the necessary action to "pet" the watch dog timer
+void esp32PetWDT()
+{
+  delay(1);
+}
+
+bool esp32SerialAvailable()
+{
+  return Serial.available();
+}
+
+void esp32SerialFlush()
+{
+  Serial.flush();
+}
+
+void esp32SerialPrint(const char * value)
+{
+  Serial.print(value);
+}
+
+uint8_t esp32SerialRead()
+{
+  return (Serial.read());
+}
+
+void esp32SerialWrite(uint8_t value)
+{
+  Serial.write(value);
+}
+
+void esp32SystemReset()
+{
+  ESP.restart();
+}
+
+const ARCH_TABLE arch = {
+  esp32BeginBoard,          //beginBoard
+  esp32BeginSerial,         //beginSerial
+  esp32BeginWDT,            //beginWDT
+  esp32EepromBegin,         //eepromBegin
+  esp32EepromCommit,        //eepromCommit
+  esp32PetWDT,              //petWDT
+  esp32SerialAvailable,     //serialAvailable
+  esp32SerialFlush,         //serialFlush
+  esp32SerialPrint,         //serialPrint
+  esp32SerialRead,          //serialRead
+  esp32SerialWrite,         //serialWrite
+  esp32SystemReset          //systemReset
+};
+
+#endif  //__ESP32_H__
+#endif  //ARDUINO_ARCH_ESP32

--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -1,0 +1,166 @@
+#if defined(ARDUINO_ARCH_SAMD)
+#ifndef __SAMD_H__
+
+#include <FlashAsEEPROM_SAMD.h> //Click here to get the library: http://librarymanager/All#FlashStorage_SAMD21 v1.2.1 by Khoi Hoang
+#include <WDTZero.h> //https://github.com/javos65/WDTZero
+WDTZero myWatchDog;
+
+void samdBeginBoard()
+{
+  //Use ADC to check resistor divider
+  pin_boardID = A2;
+
+  pin_cs = 5;
+  pin_dio0 = 7; //aka A0
+  pin_dio1 = 10; //aka A1
+  pin_txen = 2;
+  pin_rxen = 3;
+  pin_rst = 6;
+  pin_cts = 30;
+  pin_rts = 38;
+  pin_txLED = 31;
+  pin_rxLED = A5;
+  pin_rssi1LED = A3;
+  pin_rssi2LED = A4;
+  pin_rssi3LED = 8;
+  pin_rssi4LED = 9;
+
+  pin_trainButton = 4;
+
+  pin_trigger = A0;
+
+  //Flow control
+  pinMode(pin_rts, OUTPUT);
+  digitalWrite(pin_rts, HIGH);
+
+  pinMode(pin_cts, INPUT_PULLUP);
+
+  //LEDs
+  pinMode(pin_rssi1LED, OUTPUT);
+  digitalWrite(pin_rssi1LED, LOW);
+  pinMode(pin_rssi2LED, OUTPUT);
+  digitalWrite(pin_rssi2LED, LOW);
+  pinMode(pin_rssi3LED, OUTPUT);
+  digitalWrite(pin_rssi3LED, LOW);
+  pinMode(pin_rssi4LED, OUTPUT);
+  digitalWrite(pin_rssi4LED, LOW);
+
+  pinMode(pin_txLED, OUTPUT);
+  digitalWrite(pin_txLED, LOW);
+  pinMode(pin_rxLED, OUTPUT);
+  digitalWrite(pin_rxLED, LOW);
+
+  //Train button input
+  pinMode(pin_trainButton, INPUT_PULLUP);
+
+  //Debug
+  pinMode(pin_trigger, OUTPUT);
+  digitalWrite(pin_trigger, HIGH);
+
+  //Get average of board ID voltage divider
+  int val = 0;
+  for (int x = 0 ; x < 8 ; x++)
+    val += analogRead(pin_boardID);
+  val /= 8;
+
+  //Convert ADC to volts
+  float boardID = 3.3 * val / 1024;
+
+  //Use ADC to check board ID resistor divider
+  if (boardID > 1.64 * 0.9 && boardID < 1.64 * 1.1)
+  {
+    strcpy(platformPrefix, "SAMD21 1W 915MHz");
+  }
+  else
+  {
+    strcpy(platformPrefix, "SAMD21 1W");
+  }
+}
+
+void samdBeginSerial(uint16_t serialSpeed)
+{
+  Serial1.begin(serialSpeed);
+
+#if defined(ENABLE_DEVELOPER)
+  //Wait for serial to come online for debug printing
+  while (!Serial);
+#endif  //ENABLE_DEVELOPER
+}
+
+void samdBeginWDT()
+{
+  myWatchDog.setup(WDT_HARDCYCLE250m);  // Initialize WDT with 250ms timeout
+  petTimeoutHalf = 250 / 2;
+}
+
+void samdEepromBegin()
+{
+}
+
+void samdEepromCommit()
+{
+  EEPROM.commit();
+}
+
+//Perform the necessary action to "pet" the watch dog timer
+void samdPetWDT()
+{
+  //This takes 4-5ms to complete
+  myWatchDog.clear();
+}
+
+bool samdSerialAvailable()
+{
+  return (Serial.available() || Serial1.available());
+}
+
+void samdSerialFlush()
+{
+  Serial.flush();
+  Serial1.flush();
+}
+
+void samdSerialPrint(const char * value)
+{
+  Serial.print(value);
+  Serial1.print(value);
+}
+
+uint8_t samdSerialRead()
+{
+  byte incoming = 0;
+  if (Serial.available())
+    incoming = Serial.read();
+  else if (Serial1.available())
+    incoming = Serial1.read();
+  return (incoming);
+}
+
+void samdSerialWrite(uint8_t value)
+{
+  Serial.write(value);
+  Serial1.write(value);
+}
+
+void samdSystemReset()
+{
+  NVIC_SystemReset();
+}
+
+const ARCH_TABLE arch = {
+  samdBeginBoard,             //beginBoard
+  samdBeginSerial,            //beginSerial
+  samdBeginWDT,               //beginWDT
+  samdEepromBegin,            //eepromBegin
+  samdEepromCommit,           //eepromCommit
+  samdPetWDT,                 //petWDT
+  samdSerialAvailable,        //serialAvailable
+  samdSerialFlush,            //serialFlush
+  samdSerialPrint,            //serialPrint
+  samdSerialRead,             //serialRead
+  samdSerialWrite,            //serialWrite
+  samdSystemReset             //systemReset
+};
+
+#endif  //__SAMD_H__
+#endif  //ARDUINO_ARCH_SAMD

--- a/Firmware/LoRaSerial_Firmware/Begin.ino
+++ b/Firmware/LoRaSerial_Firmware/Begin.ino
@@ -1,95 +1,8 @@
 //Based on hardware features, determine which hardware this is
 void beginBoard()
 {
-#if defined(ARDUINO_ARCH_ESP32)
-  //Lower power boards
-  pin_cs = 15;
-  pin_dio0 = 26; //aka A0
-  pin_dio1 = 25; //aka A1
-  pin_rst = 32;
-
-  pin_trigger = 13;
-
-  pin_trainButton = 0;
-
-  //Debug
-  pinMode(pin_trigger, OUTPUT);
-  digitalWrite(pin_trigger, HIGH);
-
-  strcpy(platformPrefix, "ESP32 100mW");
-
-#elif defined(ARDUINO_ARCH_SAMD)
-
-  //Use ADC to check resistor divider
-  pin_boardID = A2;
-
-  pin_cs = 5;
-  pin_dio0 = 7; //aka A0
-  pin_dio1 = 10; //aka A1
-  pin_txen = 2;
-  pin_rxen = 3;
-  pin_rst = 6;
-  pin_cts = 30;
-  pin_rts = 38;
-  pin_txLED = 31;
-  pin_rxLED = A5;
-  pin_rssi1LED = A3;
-  pin_rssi2LED = A4;
-  pin_rssi3LED = 8;
-  pin_rssi4LED = 9;
-
-  pin_trainButton = 4;
-
-  pin_trigger = A0;
-
-  //Flow control
-  pinMode(pin_rts, OUTPUT);
-  digitalWrite(pin_rts, HIGH);
-
-  pinMode(pin_cts, INPUT_PULLUP);
-
-  //LEDs
-  pinMode(pin_rssi1LED, OUTPUT);
-  digitalWrite(pin_rssi1LED, LOW);
-  pinMode(pin_rssi2LED, OUTPUT);
-  digitalWrite(pin_rssi2LED, LOW);
-  pinMode(pin_rssi3LED, OUTPUT);
-  digitalWrite(pin_rssi3LED, LOW);
-  pinMode(pin_rssi4LED, OUTPUT);
-  digitalWrite(pin_rssi4LED, LOW);
-
-  pinMode(pin_txLED, OUTPUT);
-  digitalWrite(pin_txLED, LOW);
-  pinMode(pin_rxLED, OUTPUT);
-  digitalWrite(pin_rxLED, LOW);
-
-  //Train button input
-  pinMode(pin_trainButton, INPUT_PULLUP);
-
-  //Debug
-  pinMode(pin_trigger, OUTPUT);
-  digitalWrite(pin_trigger, HIGH);
-
-  //Get average of board ID voltage divider
-  int val = 0;
-  for (int x = 0 ; x < 8 ; x++)
-    val += analogRead(pin_boardID);
-  val /= 8;
-
-  //Convert ADC to volts
-  float boardID = 3.3 * val / 1024;
-
-  //Use ADC to check board ID resistor divider
-  if (boardID > 1.64 * 0.9 && boardID < 1.64 * 1.1)
-  {
-    strcpy(platformPrefix, "SAMD21 1W 915MHz");
-  }
-  else
-  {
-    strcpy(platformPrefix, "SAMD21 1W");
-  }
-
-#endif
+  //Initialize the board specific hardware
+  arch.beginBoard();
 
   //Dashbord Blink LEDs
   for (int x = 0 ; x < 3 ; x++)
@@ -160,16 +73,6 @@ void beginButton()
   }
 }
 
-void beginWDT()
-{
-#if defined(ARDUINO_ARCH_SAMD)
-  myWatchDog.setup(WDT_HARDCYCLE250m);  // Initialize WDT with 250ms timeout
-  petTimeoutHalf = 250 / 2;
-#elif defined(ARDUINO_ARCH_ESP32)
-  petTimeoutHalf = 1000 / 2;
-#endif
-}
-
 //Delay with pets of WDT when needed
 void delayWDT(uint16_t delayAmount)
 {
@@ -184,35 +87,16 @@ void delayWDT(uint16_t delayAmount)
 void beginSerial(uint16_t serialSpeed)
 {
   Serial.begin(serialSpeed);
-#if defined(ARDUINO_ARCH_SAMD)
-  Serial1.begin(serialSpeed);
-#endif
-
-#if defined(ENABLE_DEVELOPER)
-  //Wait for serial to come online for debug printing
-#if defined(ARDUINO_ARCH_ESP32)
-  delay(500);
-#elif defined(ARDUINO_ARCH_SAMD)
-  while (!Serial);
-#endif
-#endif
+  arch.beginSerial(serialSpeed);
 }
 
 void petWDT()
 {
-  //Petting the dog takes a really long time on the SAMD21, 4-5ms to complete
-  //so we don't always clear it, only after we've passed the half way point
-  //Similarly for ESP32, we don't want to delay 1ms every loop of Serial.available()
+  //Petting the dog takes a long time so its only done after we've passed the
+  //half way point
   if (millis() - lastPet > petTimeoutHalf)
   {
     lastPet = millis();
-
-#if defined(ARDUINO_ARCH_SAMD)
-    myWatchDog.clear();
-#elif defined(ARDUINO_ARCH_ESP32)
-    delay(1);
-#endif
-
+    arch.petWDT();
   }
-
 }

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -79,20 +79,6 @@ uint8_t pin_rssi4LED = 255;
 uint8_t pin_boardID = 255;
 
 uint8_t pin_trigger = 255;
-//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-//EEPROM for storing settings
-//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#if defined(ARDUINO_ARCH_ESP32)
-
-#include <EEPROM.h>
-#define EEPROM_SIZE 1024 //ESP32 emulates EEPROM in non-volatile storage (external flash IC). Max is 508k.
-
-#elif defined(ARDUINO_ARCH_SAMD)
-
-#include <FlashAsEEPROM_SAMD.h> //Click here to get the library: http://librarymanager/All#FlashStorage_SAMD21 v1.2.1 by Khoi Hoang
-
-#endif
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Radio Library
@@ -111,14 +97,6 @@ float *channels;
 GCM <AES128> gcm;
 
 uint8_t AESiv[12] = {0}; //Set during hop table generation
-//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-//Watchdog
-//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#if defined(ARDUINO_ARCH_SAMD)
-#include <WDTZero.h> //https://github.com/javos65/WDTZero
-WDTZero myWatchDog;
-#endif
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Buttons - Interrupt driven and debounce
@@ -208,6 +186,12 @@ int trainCylonNumber = 0b0001;
 int trainCylonDirection = -1;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+//Architecture variables
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#include "Arch_ESP32.h"
+#include "Arch_SAMD.h"
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
 void setup()
 {
   beginSerial(57600); //Default for debug messages before board begins
@@ -222,7 +206,7 @@ void setup()
 
   beginButton(); //Start watching the train button
 
-  beginWDT(); //Start watchdog timer
+  arch.beginWDT(); //Start watchdog timer
 
   systemPrintln("LRS");
 }

--- a/Firmware/LoRaSerial_Firmware/NVM.ino
+++ b/Firmware/LoRaSerial_Firmware/NVM.ino
@@ -1,8 +1,6 @@
 void loadSettings()
 {
-#if defined(ARDUINO_ARCH_ESP32)
-  EEPROM.begin(EEPROM_SIZE);
-#endif
+  arch.eepromBegin();
 
   //Check to see if EEPROM is blank
   uint32_t testRead = 0;
@@ -43,9 +41,7 @@ void recordSystemSettings()
   settings.sizeOfSettings = sizeof(settings);
   EEPROM.put(0, settings);
 
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD)
-  EEPROM.commit();
-#endif
+  arch.eepromCommit();
 }
 
 void eepromErase()
@@ -56,8 +52,6 @@ void eepromErase()
 
     EEPROM.write(i, 0);
 
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD)
-    EEPROM.commit();
-#endif
+    arch.eepromCommit();
   }
 }

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -75,11 +75,7 @@ void updateSerial()
   }
 
   //Look for local incoming serial
-#if defined(ARDUINO_ARCH_SAMD)
-  while ((Serial.available() || Serial1.available()) && transactionComplete == false)
-#else
-  while (Serial.available() && transactionComplete == false)
-#endif
+  while (arch.serialAvailable() && transactionComplete == false)
   {
     rxLED(true); //Turn on LED during serial reception
 

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -2,11 +2,7 @@ void systemPrint(const char* value)
 {
   if (printerEndpoint == PRINT_TO_SERIAL)
   {
-    Serial.print(value);
-
-#if defined(ARDUINO_ARCH_SAMD)
-    Serial1.print(value);
-#endif
+    arch.serialPrint(value);
   }
   else if (printerEndpoint == PRINT_TO_RF)
   {
@@ -76,34 +72,17 @@ void systemPrintln()
 
 void systemWrite(uint8_t value)
 {
-  Serial.write(value);
-
-#if defined(ARDUINO_ARCH_SAMD)
-  Serial1.write(value);
-#endif
+  arch.serialWrite(value);
 }
 
 void systemFlush()
 {
-  Serial.flush();
-
-#if defined(ARDUINO_ARCH_SAMD)
-  Serial1.flush();
-#endif
+  arch.serialFlush();
 }
 
 uint8_t systemRead()
 {
-  byte incoming = 0;
-#if defined(ARDUINO_ARCH_SAMD)
-  if (Serial.available())
-    incoming = Serial.read();
-  else if (Serial1.available())
-    incoming = Serial1.read();
-#else
-  incoming = Serial.read();
-#endif
-  return (incoming);
+  return (arch.serialRead());
 }
 
 //Check the train button and change state accordingly
@@ -173,11 +152,7 @@ void updateButton()
 //Platform specific reset commands
 void systemReset()
 {
-#if defined(ARDUINO_ARCH_SAMD)
-  NVIC_SystemReset();
-#elif defined(ARDUINO_ARCH_ESP32)
-  ESP.restart();
-#endif
+  arch.systemReset();
 }
 
 //Encrypt a given array in place

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -160,3 +160,32 @@ struct struct_online {
   bool radio = false;
   bool eeprom = false;
 } online;
+
+typedef void (* ARCH_BEGIN_BOARD)();
+typedef void (* ARCH_BEGIN_SERIAL)(uint16_t serialSpeed);
+typedef void (* ARCH_BEGIN_WDT)();
+typedef void (* ARCH_EEPROM_BEGIN)();
+typedef void (* ARCH_EEPROM_COMMIT)();
+typedef void (* ARCH_PET_WDT)();
+typedef bool (* ARCH_SERIAL_AVAILABLE)();
+typedef void (* ARCH_SERIAL_FLUSH)();
+typedef void (* ARCH_SERIAL_PRINT)(const char * value);
+typedef uint8_t (* ARCH_SERIAL_READ)();
+typedef void (* ARCH_SERIAL_WRITE)(uint8_t value);
+typedef void (* ARCH_SYSTEM_RESET)();
+
+typedef struct _ARCH_TABLE
+{
+  ARCH_BEGIN_BOARD beginBoard;    //Initialize the board
+  ARCH_BEGIN_SERIAL beginSerial;  //Finish initializing the serial port
+  ARCH_BEGIN_WDT beginWDT;        //Initialize the watchdog timer
+  ARCH_EEPROM_BEGIN eepromBegin;  //Start an EEPROM operation
+  ARCH_EEPROM_COMMIT eepromCommit;//Done with the EEPROM operation
+  ARCH_PET_WDT petWDT;            //Reset the expiration time for the WDT
+  ARCH_SERIAL_AVAILABLE serialAvailable;  //Determine if serial data is available
+  ARCH_SERIAL_FLUSH serialFlush;  //Flush the serial port
+  ARCH_SERIAL_PRINT serialPrint;  //Print the specified string value
+  ARCH_SERIAL_READ serialRead;    //Read a byte from the serial port
+  ARCH_SERIAL_WRITE serialWrite;  //Print the specified character
+  ARCH_SYSTEM_RESET systemReset;  //Reset the system
+} ARCH_TABLE;


### PR DESCRIPTION
Eliminate most of the #ifdefs with the following changes:
*  Add Arch_ESP32.h and Arch_SAMD.h files.
*  Include the new .h files in LoRaSerial_Firmware.ino.
*  Move the architecture specific code into the appropriate .h file.
*  Use the ARCH_TABLE structure defined in settings.h to reference the
architecture specific code.