### PR TITLE
Handle backspace in command mode

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -114,11 +114,29 @@ void updateSerial()
         ; //Do nothing
       else
       {
-        systemWrite(incoming); //Always echo during command mode
+        if (incoming == 8)
+        {
+          if (commandLength > 0)
+          {
+            //Remove this character from the command buffer
+            commandLength--;
 
-        //Move this character into the command buffer
-        commandBuffer[commandLength++] = toupper(incoming);
-        commandLength %= sizeof(commandBuffer);
+            //Erase the previous character
+            systemWrite(incoming);
+            systemWrite(' ');
+            systemWrite(incoming);
+          }
+          else
+            systemWrite(7);
+        }
+        else
+        {
+          systemWrite(incoming); //Always echo during command mode
+
+          //Move this character into the command buffer
+          commandBuffer[commandLength++] = toupper(incoming);
+          commandLength %= sizeof(commandBuffer);
+        }
       }
     }
     else


### PR DESCRIPTION
This change implemtents:
* Echo backspace, space, backspace to erase the character on the screen
* Removes the character from the command buffer
* Echos bell when the command buffer is empty

Debugged on STM32 version of LoRaSerial
