### PR TITLE
Verify AES encryption key and block counter lengths

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
@@ -107,13 +107,10 @@ void esp32SystemReset()
   ESP.restart();
 }
 
-void esp32UniqueID(uint32_t * unique128_BitID)
+void esp32UniqueID(uint8_t * unique128_BitID)
 {
-  unique128_BitID[0] = 0;
-  unique128_BitID[1] = 0;
-  unique128_BitID[2] = 0;
-  unique128_BitID[3] = 0;
-  esp_read_mac((uint8_t *)unique128_BitID, ESP_MAC_WIFI_STA);
+  memset(unique128_BitID, 0, UNIQUE_ID_BYTES);
+  esp_read_mac(unique128_BitID, ESP_MAC_WIFI_STA);
 }
 
 const ARCH_TABLE arch = {

--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -208,13 +208,17 @@ void samdSystemReset()
   NVIC_SystemReset();
 }
 
-void samdUniqueID(uint32_t * unique128_BitID)
+void samdUniqueID(uint8_t * unique128_BitID)
 {
+  uint32_t id[UNIQUE_ID_BYTES/4];
+
   //Read the CPU's unique ID value
-  unique128_BitID[0] = *(uint32_t *)0x0080a00c;
-  unique128_BitID[1] = *(uint32_t *)0x0080a040;
-  unique128_BitID[2] = *(uint32_t *)0x0080a044;
-  unique128_BitID[3] = *(uint32_t *)0x0080a048;
+  id[0] = *(uint32_t *)0x0080a00c;
+  id[1] = *(uint32_t *)0x0080a040;
+  id[2] = *(uint32_t *)0x0080a044;
+  id[3] = *(uint32_t *)0x0080a048;
+
+  memcpy(unique128_BitID, id, UNIQUE_ID_BYTES);
 }
 
 const ARCH_TABLE arch = {

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -126,7 +126,7 @@ bool commandAT(const char * commandString)
   //ATIx commands
   else if (commandString[2] == 'I' && commandLength == 4)
   {
-    uint32_t uniqueID[4];
+    uint8_t uniqueID[UNIQUE_ID_BYTES];
 
     switch (commandString[3])
     {

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -57,6 +57,7 @@ const int FIRMWARE_VERSION_MINOR = 0;
 #define LRS_IDENTIFIER (FIRMWARE_VERSION_MAJOR * 0x10 + FIRMWARE_VERSION_MINOR)
 
 #define MAX_PACKET_SIZE 255 //Limited by SX127x
+#define UNIQUE_ID_BYTES 16 //Number of bytes in the unique ID
 
 #include "settings.h"
 

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -57,7 +57,9 @@ const int FIRMWARE_VERSION_MINOR = 0;
 #define LRS_IDENTIFIER (FIRMWARE_VERSION_MAJOR * 0x10 + FIRMWARE_VERSION_MINOR)
 
 #define MAX_PACKET_SIZE 255 //Limited by SX127x
-#define UNIQUE_ID_BYTES 16 //Number of bytes in the unique ID
+#define AES_IV_BYTES    12  //Number of bytes for AESiv
+#define AES_KEY_BYTES   16  //Number of bytes in the encryption key
+#define UNIQUE_ID_BYTES 16  //Number of bytes in the unique ID
 
 #include "settings.h"
 
@@ -102,7 +104,7 @@ uint8_t channelNumber = 0;
 #include <GCM.h>
 GCM <AES128> gcm;
 
-uint8_t AESiv[12] = {0}; //Set during hop table generation
+uint8_t AESiv[AES_IV_BYTES] = {0}; //Set during hop table generation
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Buttons - Interrupt driven and debounce
@@ -187,7 +189,7 @@ unsigned long lastTrainBlink = 0; //Controls LED during training
 
 Settings originalSettings; //Create a duplicate of settings during training so that we can resort as needed
 uint8_t trainNetID; //New netID passed during training
-uint8_t trainEncryptionKey[16]; //New AES key passed during training
+uint8_t trainEncryptionKey[AES_KEY_BYTES]; //New AES key passed during training
 
 bool inCommandMode = false; //Normal data is prevented from entering serial output when in command mode
 uint8_t commandLength = 0;

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -251,7 +251,7 @@ void systemReset()
 //Encrypt a given array in place
 void encryptBuffer(uint8_t *bufferToEncrypt, uint8_t arraySize)
 {
-  gcm.setKey(settings.encryptionKey, gcm.keySize());
+  gcm.setKey(settings.encryptionKey, sizeof(settings.encryptionKey));
   gcm.setIV(AESiv, sizeof(AESiv));
 
   gcm.encrypt(bufferToEncrypt, bufferToEncrypt, arraySize);
@@ -260,7 +260,7 @@ void encryptBuffer(uint8_t *bufferToEncrypt, uint8_t arraySize)
 //Decrypt a given array in place
 void decryptBuffer(uint8_t *bufferToDecrypt, uint8_t arraySize)
 {
-  gcm.setKey(settings.encryptionKey, gcm.keySize());
+  gcm.setKey(settings.encryptionKey, sizeof(settings.encryptionKey));
   gcm.setIV(AESiv, sizeof(AESiv));
 
   gcm.decrypt(bufferToDecrypt, bufferToDecrypt, arraySize);

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -154,14 +154,13 @@ void systemPrintTimestamp()
   }
 }
 
-void systemPrintUniqueID(uint32_t * uniqueID)
+void systemPrintUniqueID(uint8_t * uniqueID)
 {
-  uint8_t * id = (uint8_t *)uniqueID;
   int index;
 
   //Display in the same byte order as dump output
-  for (index = 0; index < 16; index++)
-    systemPrint(id[index], HEX);
+  for (index = 0; index < UNIQUE_ID_BYTES; index++)
+    systemPrint(uniqueID[index], HEX);
 }
 
 void systemWrite(uint8_t value)

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -299,7 +299,7 @@ typedef void (* ARCH_SERIAL_PRINT)(const char * value);
 typedef uint8_t (* ARCH_SERIAL_READ)();
 typedef void (* ARCH_SERIAL_WRITE)(uint8_t value);
 typedef void (* ARCH_SYSTEM_RESET)();
-typedef void (* ARCH_UNIQUE_ID)(uint32_t * unique128_BitID);
+typedef void (* ARCH_UNIQUE_ID)(uint8_t * unique128_BitID);
 
 typedef struct _ARCH_TABLE
 {

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -231,7 +231,7 @@ typedef struct struct_settings {
   uint8_t netID = 192; //Both radios must share a network ID
   bool pointToPoint = true; //Receiving unit will check netID and ACK. If set to false, receiving unit doesn't check netID or ACK.
   bool encryptData = true; //AES encrypt each packet
-  uint8_t encryptionKey[16] = { 0x37, 0x78, 0x21, 0x41, 0xA6, 0x65, 0x73, 0x4E, 0x44, 0x75, 0x67, 0x2A, 0xE6, 0x30, 0x83, 0x08 };
+  uint8_t encryptionKey[AES_KEY_BYTES] = { 0x37, 0x78, 0x21, 0x41, 0xA6, 0x65, 0x73, 0x4E, 0x44, 0x75, 0x67, 0x2A, 0xE6, 0x30, 0x83, 0x08 };
   bool dataScrambling = false; //Use IBM Data Whitening to reduce DC bias
   uint8_t radioBroadcastPower_dbm = 30; //Transmit power in dBm. Max is 30dBm (1W), min is 14dBm (25mW).
   float frequencyMin = 902.0; //MHz


### PR DESCRIPTION
Requires #75

Replace magic numbers with defined constants.
Verify the defined constants.