### PR TITLE
V2: Add client/server training support

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -111,7 +111,24 @@ bool commandAT(const char * commandString)
         break;
       case ('T'): //Enter training mode
         reportOK();
-        beginTraining();
+        if (settings.useV2 && (!settings.pointToPoint))
+        {
+          if (settings.trainingServer)
+            beginTrainingServer();
+          else
+            beginTrainingClient();
+        }
+        else
+          beginTraining();
+        break;
+      case ('X'): //Stop the training server
+        if (trainingServerRunning && (!settings.pointToPoint) && settings.trainingServer)
+        {
+          endClientServerTraining(TRIGGER_TRAINING_SERVER_STOPPED);
+          reportOK();
+        }
+        else
+          reportERROR();
         break;
       case ('Z'): //Reboots the radio
         reportOK();
@@ -508,6 +525,12 @@ const COMMAND_ENTRY commands[] =
   {49,    0,   1,    0, TYPE_BOOL,         valInt,         "EnableCRC16",          &settings.enableCRC16},
 
   {50,    0,   1,    0, TYPE_BOOL,         valInt,         "DisplayRealMillis",    &settings.displayRealMillis},
+  {51,    0,   1,    0, TYPE_BOOL,         valInt,         "TrainingServer",       &settings.trainingServer},
+  {52,    1, 255,    0, TYPE_U8,           valInt,         "ClientRetryInterval",  &settings.clientPingRetryInterval},
+  {53,    0,   1,    0, TYPE_BOOL,         valInt,         "CopyDebug",            &settings.copyDebug},
+  {54,    0,   1,    0, TYPE_BOOL,         valInt,         "CopySerial",           &settings.copySerial},
+
+  {55,    0,   1,    0, TYPE_BOOL,         valInt,         "CopyTriggers",         &settings.copyTriggers},
 
   //Define any user parameters starting at 255 decrementing towards 0
 };

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -239,6 +239,11 @@ const int datagramsExpectingAcks = 0
 uint8_t * endOfTxData;
 CONTROL_U8 txControl;
 
+//Multi-point Training
+bool trainingServerRunning; //Training server is running
+bool trainingPreviousRxInProgress = false; //Previous RX status
+float originalChannel; //Original channel from HOP table while training is in progress
+uint8_t trainingPartnerID[UNIQUE_ID_BYTES]; //Unique ID of the training partner
 uint8_t myUniqueId[UNIQUE_ID_BYTES]; // Unique ID of this system
 
 volatile bool clearDIO1 = true; //Clear the DIO1 hop ISR when possible

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -42,6 +42,15 @@ typedef enum
   RADIO_MP_STANDBY,
   RADIO_MP_WAIT_TX_DONE,
 
+  //Training client states
+  RADIO_MP_WAIT_TX_TRAINING_PING_DONE,
+  RADIO_MP_WAIT_RX_RADIO_PARAMETERS,
+  RADIO_MP_WAIT_TX_PARAM_ACK_DONE,
+
+  //Training server states
+  RADIO_MP_WAIT_FOR_TRAINING_PING,
+  RADIO_MP_WAIT_TX_RADIO_PARAMS_DONE,
+
   RADIO_MAX_STATE,
 } RadioStates;
 RadioStates radioState = RADIO_NO_LINK_RECEIVING_STANDBY;
@@ -73,6 +82,11 @@ typedef enum
   //V2: Multi-Point data exchange
   DATAGRAM_DATAGRAM,
 
+  //V2: Multi-Point training exchange
+  DATAGRAM_TRAINING_PING,
+  DATAGRAM_TRAINING_PARAMS,
+  DATAGRAM_TRAINING_ACK,
+
   //Add new V2 datagram types before this line
   MAX_DATAGRAM_TYPE,
 
@@ -97,8 +111,10 @@ typedef enum
 const char * const v2DatagramType[] =
 {//  0       1        2        3        4           5           6
   "PING", "ACK-1", "ACK-2", "DATA", "SF6-DATA", "DATA-ACK", "HEARTBEAT",
-  //  7          8                9
-  "RMT-CMD", "RMT_RESP", "DATAGRAM_DATAGRAM"
+  //  7          8                9                10
+  "RMT-CMD", "RMT_RESP", "DATAGRAM_DATAGRAM", "TRAINING_PING",
+  //     11                12
+  "TRAINING_PARAMS", "TRAINING_ACK"
 };
 
 //Train button states
@@ -189,6 +205,21 @@ enum
   TRIGGER_COMMAND_SENT_ACK_PACKET,
   TRIGGER_COMMAND_PACKET_RESEND,
   TRIGGER_PACKET_COMMAND_DATA,
+
+  //Training client triggers
+  TRIGGER_TRAINING_CLIENT_TX_PING,            //34,  875us
+  TRIGGER_TRAINING_CLIENT_TX_PING_DONE,       //35,  900us
+  TRIGGER_TRAINING_CLIENT_RX_PARAMS,          //38,  975us
+  TRIGGER_TRAINING_CLIENT_TX_ACK,             //39, 1000us
+  TRIGGER_TRAINING_CLIENT_TX_ACK_DONE,        //40, 1025us
+  TRIGGER_TRAINING_COMPLETE,                  //41, 1050us
+
+  //Training server triggers
+  TRIGGER_TRAINING_SERVER_RX,                 //42, 1075us
+  TRIGGER_TRAINING_SERVER_TX_PARAMS,          //43, 1100us
+  TRIGGER_TRAINING_SERVER_TX_PARAMS_DONE,     //44, 1125us
+  TRIGGER_TRAINING_SERVER_RX_ACK,             //45, 1150us
+  TRIGGER_TRAINING_SERVER_STOPPED,            //46, 1175us
 };
 
 //Control where to print command output
@@ -275,6 +306,11 @@ typedef struct struct_settings {
   uint16_t overheadTime = 10; ////ms added to ack and datagram times before ACK timeout occurs
   bool enableCRC16 = false; //Append CRC-16 to packet, check CRC-16 upon receive
   bool displayRealMillis = false; //true = Display the millis value without offset, false = use offset
+  bool trainingServer = false; //Default to being a client
+  uint8_t clientPingRetryInterval = 3; //Number of seconds before retransmiting the client PING
+  bool copyDebug = true; //Copy the debug parameters to the training client
+  bool copySerial = true; //Copy the serial parameters to the training client
+  bool copyTriggers = true; //Copy the trigger parameters to the training client
 } Settings;
 Settings settings;
 

--- a/Firmware/Tools/Command_Validation_Script.txt
+++ b/Firmware/Tools/Command_Validation_Script.txt
@@ -452,9 +452,34 @@ ats50=1
 ats50=2
 ats50=0
 
-# Invalid commands
+# TrainingServer
 ats51=1
-ats51?
+ats51=2
+ats51=0
+
+# ClientRetryInterval
+ats52=1
+ats52=2
+ats52=0
+
+# CopyDebug
+ats53=1
+ats53=2
+ats53=0
+
+# CopySerial
+ats54=1
+ats54=2
+ats54=0
+
+# CopyTriggers
+ats55=1
+ats55=2
+ats55=0
+
+# Invalid commands
+ats56=1
+ats56?
 
 ats255=1
 ats255?

--- a/Firmware/Tools/Results/Command_Validation_Results.txt
+++ b/Firmware/Tools/Results/Command_Validation_Results.txt
@@ -42,7 +42,7 @@ SparkFun LoRaSerial SAMD21 1W 915MHz
 ati3
 -157
 ati4
-248
+15
 ati5
 506
 ati6
@@ -50,7 +50,7 @@ ati6
 ati7
 0
 ati8
-B2A99BF24A34555020312E34162815FF
+E5D60B0B4A34555020312E34212815FF
 ati9
 ERROR
 ati0
@@ -105,6 +105,11 @@ ATS47:DebugDatagrams=0
 ATS48:OverHeadtime=10
 ATS49:EnableCRC16=0
 ATS50:DisplayRealMillis=0
+ATS51:TrainingServer=0
+ATS52:ClientRetryInterval=3
+ATS53:CopyDebug=1
+ATS54:CopySerial=1
+ATS55:CopyTriggers=1
 ats28=0
 OK
 # SerialSpeed
@@ -919,11 +924,61 @@ ERROR
 ats50=0
 DisplayRealMillis=0
 OK
-# Invalid commands
+# TrainingServer
 ERROR
 ats51=1
+TrainingServer=1
+OK
+ats51=2
 ERROR
-ats51?
+ats51=0
+TrainingServer=0
+OK
+# ClientRetryInterval
+ERROR
+ats52=1
+ClientRetryInterval=1
+OK
+ats52=2
+ClientRetryInterval=2
+OK
+ats52=0
+ERROR
+# CopyDebug
+ERROR
+ats53=1
+CopyDebug=1
+OK
+ats53=2
+ERROR
+ats53=0
+CopyDebug=0
+OK
+# CopySerial
+ERROR
+ats54=1
+CopySerial=1
+OK
+ats54=2
+ERROR
+ats54=0
+CopySerial=0
+OK
+# CopyTriggers
+ERROR
+ats55=1
+CopyTriggers=1
+OK
+ats55=2
+ERROR
+ats55=0
+CopyTriggers=0
+OK
+# Invalid commands
+ERROR
+ats56=1
+ERROR
+ats56?
 ERROR
 ats255=1
 ERROR
@@ -933,7 +988,11 @@ ati0
 ATS1:AirSpeed=4800
 ATS24:AutoTune=0
 ATS13:Bandwidth=500.00
+ATS52:ClientRetryInterval=2
 ATS15:CodingRate=8
+ATS53:CopyDebug=0
+ATS54:CopySerial=0
+ATS55:CopyTriggers=0
 ATS6:DataScrambling=0
 ATS20:Debug=0
 ATS47:DebugDatagrams=0
@@ -973,6 +1032,7 @@ ATS0:SerialSpeed=57600
 ATS27:SortParametersByName=1
 ATS14:SpreadFactor=9
 ATS16:SyncWord=18
+ATS51:TrainingServer=0
 ATS40:TriggerEnable: 31-0=-1
 ATS41:TriggerEnable: 63-32=-1
 ATS38:TriggerWidth=25


### PR DESCRIPTION
Requires #59, #73 - #83

Verified with 3 clients using the following server script:

    +++
    at&f
    ats28=1
    ats1=9600
    ats2=83
    ats3=0
    ats5=537061726b46756e3230323231303130
    ats6=1
    ats7=16
    ats11=0
    ats35=1
    ats36=1
    ats37=1
    ats45=1
    ats47=1
    ats51=1
    at&w
    att

The following client script was used:

    +++
    at&f
    ats28=1
    ats3=0
    ats45=1
    att
