### PR TITLE
Add RX Flow_Control test sketch

### DIFF
--- a/Firmware/Test_Sketches/Flow_Control/Arch_SAMD.h
+++ b/Firmware/Test_Sketches/Flow_Control/Arch_SAMD.h
@@ -1,0 +1,122 @@
+#if defined(ARDUINO_ARCH_SAMD)
+#ifndef __SAMD_H__
+
+/*
+  Data flow
+                   +--------------+
+                   |     SAMD     |
+                   |              |
+    TTL Serial <-->| Serial1      |       +--------------+
+                   |          SPI |<----->| SX1276 Radio |<---> Antenna
+    USB Serial <-->| Serial       |       +--------------+         ^
+                   +--------------+                                |
+                                                                   |
+                   +--------------+                                |
+                   |     SAMD     |                                |
+                   |              |                                |
+    TTL Serial <-->| Serial1      |       +--------------+         V
+                   |          SPI |<----->| SX1276 Radio |<---> Antenna
+    USB Serial <-->| Serial       |       +--------------+
+                   +--------------+
+
+                          +--------------+
+                          | SAMD         |
+                          |              |
+                          |      PB02 A5 |---> rxLED
+                          |      PB23 31 |---> txLED
+                          |              |
+                          |      PA07  9 |---> rssi4LED
+                          |      PA06  8 |---> rssi3LED
+                          |      PA05 A4 |---> rssi2LED
+                          |      PA04 A3 |---> rssi1LED
+                          |              |
+    USB_D- <------------->| 28 PA24      |
+    USB_D+ <------------->| 29 PA25      |
+                          |              |
+                          |      PA15  5 |---> cs -----> LORA_CS/
+                          |      PA17 13 |---> SCLK ---> SPI_SCK
+                          |      PA16 11 |---> MOSI ---> SPI_PICO
+                          |      PA19 12 |<--- MISO ---> SPI_POCI
+                          |              |
+    RTS-0 <------ rts <---| 38 PA13      |
+    TX-0 <------- tx <----| 0  PA10      |
+    RX-I_LV <---- rx ---->| 1  PA11      |
+    CTS-I_LV <--- cts --->| 30 PB22      |
+                          |              |
+                          |      PA09  3 |---> rxen ---> LORA_RXEN
+                          |      PA14  2 |---> txen ---> LORA_TXEN
+                          |              |
+                          |      PA18 10 |<--- dio1 <--- LORA_D1 (Freq Change)
+                          |      PA21  7 |<--- dio0 <--- LORA_D0 (TX Done)
+                          |              |
+                          |      PA20  6 |---> rst ----> LORA_RST/
+                          |              |
+                          |      PA23 21 |---> SCL
+                          |      PA22 20 |---> SDA
+                          +--------------+
+*/
+
+void samdBeginBoard()
+{
+  pin_cts = 30;
+  pin_rts = 38;
+  pin_txLED = 31;
+  pin_rxLED = A5;
+
+  //Flow control
+  pinMode(pin_rts, OUTPUT);
+  digitalWrite(pin_rts, INVERT_RTS_CTS ? HIGH : LOW); //Don't give me more
+
+  pinMode(pin_cts, INPUT_PULLUP);
+
+  //LEDs
+  pinMode(pin_txLED, OUTPUT);
+  digitalWrite(pin_txLED, LOW);
+  pinMode(pin_rxLED, OUTPUT);
+  digitalWrite(pin_rxLED, LOW);
+}
+
+void samdBeginSerial(uint16_t serialSpeed)
+{
+  //Wait for serial to come online for debug printing
+  SerialUSB.begin(serialSpeed);
+  while (!SerialUSB);
+
+  Serial1.begin(serialSpeed);
+}
+
+bool samdSerialAvailable()
+{
+  return (SerialUSB.available() || Serial1.available());
+}
+
+void samdSerialFlush()
+{
+  SerialUSB.flush();
+  Serial1.flush();
+}
+
+void samdSerialPrint(const char * value)
+{
+  SerialUSB.print(value);
+  Serial1.print(value);
+}
+
+uint8_t samdSerialRead()
+{
+  byte incoming = 0;
+  if (SerialUSB.available())
+    incoming = SerialUSB.read();
+  else if (Serial1.available())
+    incoming = Serial1.read();
+  return (incoming);
+}
+
+void samdSerialWrite(uint8_t value)
+{
+  SerialUSB.write(value);
+  Serial1.write(value);
+}
+
+#endif  //__SAMD_H__
+#endif  //ARDUINO_ARCH_SAMD

--- a/Firmware/Test_Sketches/Flow_Control/Flow_Control.ino
+++ b/Firmware/Test_Sketches/Flow_Control/Flow_Control.ino
@@ -1,0 +1,95 @@
+/*
+  October 26 2022
+  SparkFun Electronics
+  Lee Leahy
+
+  Verify flow control operation
+
+  Compiled with Arduino v1.8.15
+*/
+
+#define UNUSED(x) (void)(x)
+
+#define INVERT_RTS_CTS      1
+
+//Hardware connections
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//These pins are set in beginBoard()
+#define PIN_UNDEFINED   255
+
+uint8_t pin_rts = PIN_UNDEFINED;
+uint8_t pin_cts = PIN_UNDEFINED;
+uint8_t pin_txLED = PIN_UNDEFINED;
+uint8_t pin_rxLED = PIN_UNDEFINED;
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+//Global variables - Serial
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+//Buffer to store bytes incoming from serial before broadcasting over LoRa
+uint8_t serialTransmitBuffer[1024 * 1]; //Bytes received from RF waiting to be printed out UART. Buffer up to 1s of bytes at 4k
+
+uint16_t txHead = 0;
+uint16_t txTail = 0;
+
+//When RTS is asserted, host says it's ok to send data
+bool rtsAsserted;
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+/* Data Flow
+
+                             USB or UART
+                                  |
+                                  | Flow control: RTS for UART
+                                  |      Off: Buffer full
+                                  |      On: Buffer drops below half full
+                                  V
+                        serialTransmitBuffer
+                                  |
+                                  | Flow control: CTS for UART
+                                  |
+                                  V
+                             USB or UART
+
+*/
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+//Architecture variables
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#include "Arch_SAMD.h"
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+void setup()
+{
+  samdBeginSerial(57600);
+  samdBeginBoard();
+  randomSeed(5);
+
+  //Enable the flow of data from the remote serial port into the SAMD
+  updateRTS(true);
+}
+
+void loop()
+{
+  updateSerial(); //Store incoming and print outgoing
+}
+
+void systemPrint(int value)
+{
+  char string[20];
+  sprintf(string, "%d", value);
+  SerialUSB.print(string);
+}
+
+void systemPrint(const char * string)
+{
+  SerialUSB.print(string);
+}
+
+void systemPrintln()
+{
+  SerialUSB.print("\r\n");
+}

--- a/Firmware/Test_Sketches/Flow_Control/Serial.ino
+++ b/Firmware/Test_Sketches/Flow_Control/Serial.ino
@@ -1,0 +1,132 @@
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//Serial RX - Data arriving at the USB or serial port
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+//Returns true if CTS is asserted (host says it's ok to send data)
+bool isCTS()
+{
+  return (digitalRead(pin_cts) == (INVERT_RTS_CTS ? LOW : HIGH));
+}
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//Serial TX - Data being sent to the USB or serial port
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+//Return number of bytes sitting in the serial transmit buffer
+uint16_t availableTXBytes()
+{
+  if (txHead >= txTail)
+    return (txHead - txTail);
+  return (sizeof(serialTransmitBuffer) - txTail + txHead);
+}
+
+//Returns true if CTS is asserted (host says it's ok to send data)
+void updateRTS(bool assertRTS)
+{
+  rtsAsserted = assertRTS;
+  digitalWrite(pin_rts, assertRTS ^ INVERT_RTS_CTS);
+}
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//Move serial data through the system
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+//See if there's any serial from the remote radio that needs printing
+//Record any characters to the receive buffer
+//Scan for escape characters
+void updateSerial()
+{
+  bool bufferFull;
+  static uint32_t bufferFullCount;
+  static bool copyStarted;
+  static uint32_t delayMillis;
+  int x;
+  static uint32_t lastTime;
+  static uint32_t totalDelayMillis;
+
+  //Determine if bytea are available for transmission
+  while (availableTXBytes() && isCTS() && ((millis() - lastTime) >= delayMillis))
+  {
+    //Account for the delay time.
+    lastTime = millis();
+    totalDelayMillis += delayMillis;
+    delayMillis = random(1, 15);
+    copyStarted = true;
+
+    //Turn on LED during serial transmissions
+    txLED(true);
+
+    //Send a byte to the host
+    samdSerialWrite(serialTransmitBuffer[txTail++]);
+    txTail %= sizeof(serialTransmitBuffer);
+
+    //Assert RTS when enough space is available
+    if (availableTXBytes() <= (sizeof(serialTransmitBuffer) / 2))
+      updateRTS(true); //Ok to send more
+
+    //Since the UART does not have RTS and CTS, prevent loss of serial data
+    //by sending one character at a time
+    samdSerialFlush();
+
+    //Turn off LED
+    txLED(false);
+  }
+
+  //Look for local incoming serial
+  if (samdSerialAvailable() && rtsAsserted)
+  {
+    do
+    {
+      rxLED(true); //Turn on LED during serial reception
+
+      //Deassert RTS when the buffer becomes full
+      if (availableTXBytes() >= (sizeof(serialTransmitBuffer) - 32))
+      {
+        updateRTS(false); //Don't give me more
+        bufferFullCount += 1;
+      }
+
+      //Get the next character
+      serialTransmitBuffer[txHead++] = samdSerialRead();
+      txHead %= sizeof(serialTransmitBuffer);
+
+      rxLED(false); //Turn off LED
+    } while (samdSerialAvailable() && rtsAsserted);
+  }
+
+  if (copyStarted && ((millis() - lastTime) >= (5 * 1000)))
+  {
+    copyStarted = false;
+    systemPrint("Delay time: ");
+    systemPrint(totalDelayMillis);
+    systemPrint(" mSec");
+    systemPrintln();
+    systemPrint("RX Buffer Full Count: ");
+    systemPrint(bufferFullCount);
+    systemPrintln();
+    bufferFullCount = 0;
+    totalDelayMillis = 0;
+  }
+}
+
+void txLED(bool illuminate)
+{
+  if (pin_txLED != PIN_UNDEFINED)
+  {
+    if (illuminate == true)
+      digitalWrite(pin_txLED, HIGH);
+    else
+      digitalWrite(pin_txLED, LOW);
+  }
+}
+
+void rxLED(bool illuminate)
+{
+  if (pin_rxLED != PIN_UNDEFINED)
+  {
+    if (illuminate == true)
+      digitalWrite(pin_rxLED, HIGH);
+    else
+      digitalWrite(pin_rxLED, LOW);
+  }
+}


### PR DESCRIPTION
Test case:

        States.ino --> USB in --> USB out --> st.txt

Results:

The files matched, except the following lines were added to the output file:

Delay time: 495522 mSec

RX Buffer Full Count: 135

Test case:
States.ino --> Digilent Pmod USBUart --> Serial1 --> USB Out -->st2.txt

Results:

The files matched, except the following lines were added to the output file:

Delay time: 495400 mSec

RX Buffer Full Count: 133

These lines indicated that the output took over 8 minutes to print and that the USB serial receive buffer was full over 65K times!  Therefore the SAMD21 was applying flow control back pressure on the PC limiting how fast USB serial data was allowed to leave the PC and enter the SAMD21.