### PR TITLE
Add ATS58 and ATS59 commands to invert CTS and RTS

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -86,7 +86,7 @@ void samdBeginBoard()
 
   //Flow control
   pinMode(pin_rts, OUTPUT);
-  digitalWrite(pin_rts, HIGH);
+  updateRTS(false); //Disable serial input until the radio starts
 
   pinMode(pin_cts, INPUT_PULLUP);
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -683,6 +683,8 @@ const COMMAND_ENTRY commands[] =
   {55,    0,   1,    0, TYPE_BOOL,         valInt,         "CopyTriggers",         &settings.copyTriggers},
   {56,    0,   0,    0, TYPE_KEY,          valKey,         "TrainingKey",          &settings.trainingKey},
   {57,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintLinkUpDown",      &settings.printLinkUpDown},
+  {58,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertCts",            &settings.invertCts},
+  {59,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertRts",            &settings.invertRts},
 
   //Define any user parameters starting at 255 decrementing towards 0
 };

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -164,6 +164,8 @@ const long minEscapeTime_ms = 2000; //Serial traffic must stop this amount befor
 bool inCommandMode = false; //Normal data is prevented from entering serial output when in command mode
 uint8_t commandLength = 0;
 bool remoteCommandResponse;
+
+bool rtsAsserted; //When RTS is asserted, host says it's ok to send data
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - LEDs
@@ -298,6 +300,8 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 
 //Architecture variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void updateRTS(bool assertRTS);
+
 #include "Arch_ESP32.h"
 #include "Arch_SAMD.h"
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -328,6 +332,8 @@ void setup()
   beginChannelTimer(); //Setup (but do not start) hardware timer for channel hopping
 
   arch.beginWDT(); //Start watchdog timer
+
+  updateRTS(true); //Enable serial input
 
   systemPrintTimestamp();
   systemPrintln("LRS Setup Complete");

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -459,6 +459,8 @@ typedef struct struct_settings {
   bool copyTriggers = true; //Copy the trigger parameters to the training client
   uint8_t trainingKey[AES_KEY_BYTES] = { 0x53, 0x70, 0x61, 0x72, 0x6b, 0x46, 0x75, 0x6E, 0x54, 0x72, 0x61, 0x69, 0x6e, 0x69, 0x6e, 0x67 };
   bool printLinkUpDown = false; //Print the link up and link down messages
+  bool invertCts = false; //Invert the input of CTS
+  bool invertRts = false; //Invert the output of RTS
 
   //Add new parameters immediately before this line
   //-- Add commands to set the parameters


### PR DESCRIPTION
Add invertCts and invertRts to settings.
Move setting of RTS into a subroutine to properly handle inversion. Replace the direct writes to the RTS pin with calls to the subroutine. Prevent serial input until the end of setup.