### PR TITLE
Timeout retransmission attempts using the link break timeout

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -86,7 +86,7 @@ void samdBeginBoard()
 
   //Flow control
   pinMode(pin_rts, OUTPUT);
-  digitalWrite(pin_rts, HIGH);
+  updateRTS(false); //Disable serial input until the radio starts
 
   pinMode(pin_cts, INPUT_PULLUP);
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -683,6 +683,8 @@ const COMMAND_ENTRY commands[] =
   {55,    0,   1,    0, TYPE_BOOL,         valInt,         "CopyTriggers",         &settings.copyTriggers},
   {56,    0,   0,    0, TYPE_KEY,          valKey,         "TrainingKey",          &settings.trainingKey},
   {57,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintLinkUpDown",      &settings.printLinkUpDown},
+  {58,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertCts",            &settings.invertCts},
+  {59,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertRts",            &settings.invertRts},
 
   //Define any user parameters starting at 255 decrementing towards 0
 };

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -164,6 +164,8 @@ const long minEscapeTime_ms = 2000; //Serial traffic must stop this amount befor
 bool inCommandMode = false; //Normal data is prevented from entering serial output when in command mode
 uint8_t commandLength = 0;
 bool remoteCommandResponse;
+
+bool rtsAsserted; //When RTS is asserted, host says it's ok to send data
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - LEDs
@@ -298,6 +300,8 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 
 //Architecture variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void updateRTS(bool assertRTS);
+
 #include "Arch_ESP32.h"
 #include "Arch_SAMD.h"
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -328,6 +332,8 @@ void setup()
   beginChannelTimer(); //Setup (but do not start) hardware timer for channel hopping
 
   arch.beginWDT(); //Start watchdog timer
+
+  updateRTS(true); //Enable serial input
 
   systemPrintTimestamp();
   systemPrintln("LRS Setup Complete");

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -325,6 +325,7 @@ unsigned long vcTxHeartbeatMillis;
 //Transmit control
 uint8_t * endOfTxData;
 CONTROL_U8 txControl;
+uint32_t transmitTimer;
 
 //Multi-point Training
 bool trainingServerRunning; //Training server is running

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -166,6 +166,61 @@ uint8_t commandLength = 0;
 bool remoteCommandResponse;
 
 bool rtsAsserted; //When RTS is asserted, host says it's ok to send data
+
+/* Data Flow - Point-to-Point and Multi-Point
+
+                             USB or UART
+                                  |
+                                  | inCommandMode?
+                                  |
+                     true         V        false
+                    .-------------+--------------------------.
+                    |                                        |
+                    V                                        v
+              commandBuffer                         serialReceiveBuffer
+                    |                                        |
+                    | Remote Command?                        v
+                    |                                 outgoingPacket
+       false        V         true                           |
+      .-------------+-------------.                          V
+      |                           |                Send to remote system
+      |                           V                          |
+      |                    outgoingPacket                    V
+      |                           |                   incomingBuffer
+      |                           V                          |
+      |                 Send to remote system                V
+      |                           |                serialTransmitBuffer
+      |                           V                          |
+      |                    incomingBuffer                    |
+      |                           |                          |
+      |                           V                          |
+      |                    commandRXBuffer                   |
+      |                           |                          |
+      |                           V                          |
+      |                  Command processing                  |
+      |                     checkCommand                     |
+      |                           |                          |
+      |                           V                          |
+      |                    commandTXBuffer                   |
+      |                           |                          |
+      |                           V                          |
+      |                    outgoingPacket                    |
+      |                           |                          |
+      |                           V                          |
+      |               Send back to local system              |
+      |                           |                          |
+      |                           V                          |
+      |                    incomingBuffer                    |
+      |                           |                          |
+      |                           V                          |
+      `-------------------------->+<-------------------------'
+                                  |
+                                  |
+                                  V
+                             USB or UART
+
+*/
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - LEDs

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1842,6 +1842,9 @@ void v2BreakLink()
   if (settings.printLinkUpDown)
     systemPrintln("--------- Link DOWN ---------");
   triggerEvent(TRIGGER_RADIO_RESET);
+
+  //Flush the buffers
+  resetSerial();
   changeState(RADIO_RESET);
 }
 
@@ -1893,6 +1896,9 @@ void vcBreakLink(int8_t vcIndex)
     systemPrint(vcIndex);
     systemPrintln(" Down  ---------");
   }
+
+  //Flush the buffers
+  resetSerial();
 }
 
 int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -427,7 +427,7 @@ typedef struct struct_settings {
   bool flowControl = false; //Enable the use of CTS/RTS flow control signals
   bool autoTuneFrequency = false; //Based on the last packets frequency error, adjust our next transaction frequency
   bool displayPacketQuality = false; //Print RSSI, SNR, and freqError for received packets
-  uint8_t maxResends = 2; //Attempt resends up to this number.
+  uint8_t maxResends = 0; //Attempt resends up to this number, 0 = infinite retries
   bool sortParametersByName = false; //Sort the parameter list (ATI0) by parameter name
   bool printParameterName = false; //Print the parameter name in the ATSx? response
   bool printFrequency = false; //Print the updated frequency

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -459,6 +459,8 @@ typedef struct struct_settings {
   bool copyTriggers = true; //Copy the trigger parameters to the training client
   uint8_t trainingKey[AES_KEY_BYTES] = { 0x53, 0x70, 0x61, 0x72, 0x6b, 0x46, 0x75, 0x6E, 0x54, 0x72, 0x61, 0x69, 0x6e, 0x69, 0x6e, 0x67 };
   bool printLinkUpDown = false; //Print the link up and link down messages
+  bool invertCts = false; //Invert the input of CTS
+  bool invertRts = false; //Invert the output of RTS
 
   //Add new parameters immediately before this line
   //-- Add commands to set the parameters


### PR DESCRIPTION
If settings.maxResends is set to zero, allow retransmits continue until
the link break timeout occurs, even if HEARTBEATS are being received.