### PR TITLE
Support serial data flow control across the radio link

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -86,7 +86,7 @@ void samdBeginBoard()
 
   //Flow control
   pinMode(pin_rts, OUTPUT);
-  digitalWrite(pin_rts, HIGH);
+  updateRTS(false); //Disable serial input until the radio starts
 
   pinMode(pin_cts, INPUT_PULLUP);
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -180,6 +180,7 @@ bool commandAT(const char * commandString)
         systemPrintln("  ATI22 - Display the VC bad length received");
         systemPrintln("  ATI23 - Display the VC link failures");
         systemPrintln("  ATI24 - Display the VC details");
+        systemPrintln("  ATI25 - Display the total insufficient buffer count");
         break;
       case ('0'): //ATI0 - Show user settable parameters
         displayParameters();
@@ -343,6 +344,10 @@ bool commandAT(const char * commandString)
           systemPrint("    Last HEARTBEAT millis: ");
           systemPrintln(vc->lastHeartbeatMillis);
         }
+        break;
+      case ('5'): //ATI25 - Display the total insufficient buffer count
+        systemPrint("Total insufficient buffer count: ");
+        systemPrintln(insufficientSpace);
         break;
     }
   }

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -683,6 +683,8 @@ const COMMAND_ENTRY commands[] =
   {55,    0,   1,    0, TYPE_BOOL,         valInt,         "CopyTriggers",         &settings.copyTriggers},
   {56,    0,   0,    0, TYPE_KEY,          valKey,         "TrainingKey",          &settings.trainingKey},
   {57,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintLinkUpDown",      &settings.printLinkUpDown},
+  {58,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertCts",            &settings.invertCts},
+  {59,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertRts",            &settings.invertRts},
 
   //Define any user parameters starting at 255 decrementing towards 0
 };

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -259,6 +259,7 @@ uint32_t badFrames;         //Total number of bad frames received
 uint32_t duplicateFrames;   //Total number of duplicate frames received
 uint32_t lostFrames;        //Total number of lost TX frames
 uint32_t linkFailures;      //Total number of link failures
+uint32_t insufficientSpace; //Total number of times the buffer did not have enough space
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - V2 Protocol

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -164,6 +164,8 @@ const long minEscapeTime_ms = 2000; //Serial traffic must stop this amount befor
 bool inCommandMode = false; //Normal data is prevented from entering serial output when in command mode
 uint8_t commandLength = 0;
 bool remoteCommandResponse;
+
+bool rtsAsserted; //When RTS is asserted, host says it's ok to send data
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - LEDs
@@ -298,6 +300,8 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 
 //Architecture variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+void updateRTS(bool assertRTS);
+
 #include "Arch_ESP32.h"
 #include "Arch_SAMD.h"
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -328,6 +332,8 @@ void setup()
   beginChannelTimer(); //Setup (but do not start) hardware timer for channel hopping
 
   arch.beginWDT(); //Start watchdog timer
+
+  updateRTS(true); //Enable serial input
 
   systemPrintTimestamp();
   systemPrintln("LRS Setup Complete");

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -325,6 +325,7 @@ unsigned long vcTxHeartbeatMillis;
 //Transmit control
 uint8_t * endOfTxData;
 CONTROL_U8 txControl;
+uint32_t transmitTimer;
 
 //Multi-point Training
 bool trainingServerRunning; //Training server is running

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -166,6 +166,61 @@ uint8_t commandLength = 0;
 bool remoteCommandResponse;
 
 bool rtsAsserted; //When RTS is asserted, host says it's ok to send data
+
+/* Data Flow - Point-to-Point and Multi-Point
+
+                             USB or UART
+                                  |
+                                  | inCommandMode?
+                                  |
+                     true         V        false
+                    .-------------+--------------------------.
+                    |                                        |
+                    V                                        v
+              commandBuffer                         serialReceiveBuffer
+                    |                                        |
+                    | Remote Command?                        v
+                    |                                 outgoingPacket
+       false        V         true                           |
+      .-------------+-------------.                          V
+      |                           |                Send to remote system
+      |                           V                          |
+      |                    outgoingPacket                    V
+      |                           |                   incomingBuffer
+      |                           V                          |
+      |                 Send to remote system                V
+      |                           |                serialTransmitBuffer
+      |                           V                          |
+      |                    incomingBuffer                    |
+      |                           |                          |
+      |                           V                          |
+      |                    commandRXBuffer                   |
+      |                           |                          |
+      |                           V                          |
+      |                  Command processing                  |
+      |                     checkCommand                     |
+      |                           |                          |
+      |                           V                          |
+      |                    commandTXBuffer                   |
+      |                           |                          |
+      |                           V                          |
+      |                    outgoingPacket                    |
+      |                           |                          |
+      |                           V                          |
+      |               Send back to local system              |
+      |                           |                          |
+      |                           V                          |
+      |                    incomingBuffer                    |
+      |                           |                          |
+      |                           V                          |
+      `-------------------------->+<-------------------------'
+                                  |
+                                  |
+                                  V
+                             USB or UART
+
+*/
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - LEDs

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1842,6 +1842,9 @@ void v2BreakLink()
   if (settings.printLinkUpDown)
     systemPrintln("--------- Link DOWN ---------");
   triggerEvent(TRIGGER_RADIO_RESET);
+
+  //Flush the buffers
+  resetSerial();
   changeState(RADIO_RESET);
 }
 
@@ -1893,6 +1896,9 @@ void vcBreakLink(int8_t vcIndex)
     systemPrint(vcIndex);
     systemPrintln(" Down  ---------");
   }
+
+  //Flush the buffers
+  resetSerial();
 }
 
 int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -427,7 +427,7 @@ typedef struct struct_settings {
   bool flowControl = false; //Enable the use of CTS/RTS flow control signals
   bool autoTuneFrequency = false; //Based on the last packets frequency error, adjust our next transaction frequency
   bool displayPacketQuality = false; //Print RSSI, SNR, and freqError for received packets
-  uint8_t maxResends = 2; //Attempt resends up to this number.
+  uint8_t maxResends = 0; //Attempt resends up to this number, 0 = infinite retries
   bool sortParametersByName = false; //Sort the parameter list (ATI0) by parameter name
   bool printParameterName = false; //Print the parameter name in the ATSx? response
   bool printFrequency = false; //Print the updated frequency

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -459,6 +459,8 @@ typedef struct struct_settings {
   bool copyTriggers = true; //Copy the trigger parameters to the training client
   uint8_t trainingKey[AES_KEY_BYTES] = { 0x53, 0x70, 0x61, 0x72, 0x6b, 0x46, 0x75, 0x6E, 0x54, 0x72, 0x61, 0x69, 0x6e, 0x69, 0x6e, 0x67 };
   bool printLinkUpDown = false; //Print the link up and link down messages
+  bool invertCts = false; //Invert the input of CTS
+  bool invertRts = false; //Invert the output of RTS
 
   //Add new parameters immediately before this line
   //-- Add commands to set the parameters

--- a/Firmware/Tools/Command_Validation_Script.txt
+++ b/Firmware/Tools/Command_Validation_Script.txt
@@ -33,6 +33,7 @@ ati22
 ati23
 ati24
 ati25
+ati26
 ati0
 
 ats28=0
@@ -520,9 +521,21 @@ ats57=2
 ats57=0
 ats57?
 
-# Invalid commands
+# InvertCts
 ats58=1
+ats58=2
+ats58=0
 ats58?
+
+# InvertRts
+ats59=1
+ats59=2
+ats59=0
+ats59?
+
+# Invalid commands
+ats60=1
+ats60?
 
 ats255=1
 ats255?

--- a/Firmware/Tools/Results/Command_Validation_Results.txt
+++ b/Firmware/Tools/Results/Command_Validation_Results.txt
@@ -14,6 +14,7 @@ Command summary:
   ATI? - Display the information commands
   ATIn - Display system information
   ATO - Exit command mode
+  ATR - VC link reset
   ATSn=xxx - Set parameter n's value to xxx
   ATSn? - Print parameter n's current value
   ATT - Enter training mode
@@ -47,6 +48,7 @@ ati?
   ATI22 - Display the VC bad length received
   ATI23 - Display the VC link failures
   ATI24 - Display the VC details
+  ATI25 - Display the total insufficient buffer count
 # Allow leading white space (space, tab, cr, lf)
 ERROR
         	ati
@@ -57,35 +59,35 @@ SparkFun LoRaSerial SAMD21 1W 915MHz
 	ati2
 2.0
 ati3
--157
+-105
 ati4
-218
+29
 ati5
 506
 ati6
 37782141A665734E4475672AE6308308
 ati7
-0
+2
 ati8
-E5D60B0B4A34555020312E34212815FF
+FB25B80B5730305020312E50021A0AFF
 ati9
-Total datagrams sent: 24
+Total datagrams sent: 36
 ati10
-Total datagrams received: 0
+Total datagrams received: 34
 ati11
-Total frames sent: 0
+Total frames sent: 34
 ati12
-Total frames sent: 0
+Total frames sent: 34
 ati13
 Total bad frames received: 0
 ati14
 Total duplicate frames received: 0
 ati15
-Total lost TX frames: 0
+Total lost TX frames: 201
 ati16
 Maximum datagram size: 253
 ati17
-Total link failures: 0
+Total link failures: 1
 ati18
 VC 0 frames sent: 0
 ati19
@@ -101,6 +103,8 @@ VC 0 link failures: 0
 ati24
 VC 0: Not valid!
 ati25
+Total insufficient buffer count: 0
+ati26
 ERROR
 ati0
 ATS0:SerialSpeed=57600
@@ -129,7 +133,7 @@ ATS22:HeartBeatTimeout=5000
 ATS23:FlowControl=0
 ATS24:AutoTune=0
 ATS25:DisplayPacketQuality=0
-ATS26:MaxResends=2
+ATS26:MaxResends=0
 ATS27:SortParametersByName=0
 ATS28:PrintParameterName=0
 ATS29:PrintFrequency=0
@@ -161,6 +165,8 @@ ATS54:CopySerial=1
 ATS55:CopyTriggers=1
 ATS56:TrainingKey=537061726B46756E547261696E696E67
 ATS57:PrintLinkUpDown=0
+ATS58:InvertCts=0
+ATS59:InvertRts=0
 ats28=0
 OK
 # SerialSpeed
@@ -1077,11 +1083,35 @@ PrintLinkUpDown=0
 OK
 ats57?
 PrintLinkUpDown=0
-# Invalid commands
+# InvertCts
 ERROR
 ats58=1
+InvertCts=1
+OK
+ats58=2
 ERROR
+ats58=0
+InvertCts=0
+OK
 ats58?
+InvertCts=0
+# InvertRts
+ERROR
+ats59=1
+InvertRts=1
+OK
+ats59=2
+ERROR
+ats59=0
+InvertRts=0
+OK
+ats59?
+InvertRts=0
+# Invalid commands
+ERROR
+ats60=1
+ERROR
+ats60?
 ERROR
 ats255=1
 ERROR
@@ -1118,6 +1148,8 @@ ATS11:FrequencyHop=1
 ATS9:FrequencyMax=928.000
 ATS8:FrequencyMin=902.000
 ATS22:HeartBeatTimeout=5000
+ATS58:InvertCts=0
+ATS59:InvertRts=0
 ATS12:MaxDwellTime=400
 ATS26:MaxResends=2
 ATS2:netID=192


### PR DESCRIPTION
Only read data from the serial port or USB when there is space in the serialReceiveBuffer.  Deassert RTS when serialReceiveBuffer is full.  Assert RTS when serialReceiveBuffer drops to half full and there is lots of space in the transmit buffer.
    
Testing done by sending States.ino across the radio link and verifying the resulting file.  This has been successful a couple of times, but the link is likely to break during the transfer.
    
Add ATI25 command to display the number of times there was insufficient receive buffer space at the radio layer.