### PR TITLE
Add setting to enable alternate LED usage

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -181,6 +181,7 @@ bool commandAT(const char * commandString)
         systemPrintln("  ATI23 - Display the VC link failures");
         systemPrintln("  ATI24 - Display the VC details");
         systemPrintln("  ATI25 - Display the total insufficient buffer count");
+        systemPrintln("  ATI26 - Display the total number of bad CRC frames");
         break;
       case ('0'): //ATI0 - Show user settable parameters
         displayParameters();
@@ -348,6 +349,10 @@ bool commandAT(const char * commandString)
       case ('5'): //ATI25 - Display the total insufficient buffer count
         systemPrint("Total insufficient buffer count: ");
         systemPrintln(insufficientSpace);
+        break;
+      case ('6'): //ATI26 - Display the total number of bad CRC frames
+        systemPrint("Total number of bad CRC frames: ");
+        systemPrintln(badCrc);
         break;
     }
   }
@@ -690,6 +695,8 @@ const COMMAND_ENTRY commands[] =
   {57,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintLinkUpDown",      &settings.printLinkUpDown},
   {58,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertCts",            &settings.invertCts},
   {59,    0,   1,    0, TYPE_BOOL,         valInt,         "InvertRts",            &settings.invertRts},
+
+  {60,    0,   1,    0, TYPE_BOOL,         valInt,         "AlternateLedUsage",    &settings.alternateLedUsage},
 
   //Define any user parameters starting at 255 decrementing towards 0
 };

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -87,6 +87,18 @@ uint8_t pin_rssi4LED = PIN_UNDEFINED;
 uint8_t pin_boardID = PIN_UNDEFINED;
 
 uint8_t pin_trigger = PIN_UNDEFINED;
+
+#define ALT_LED_RX_DATA     pin_rssi1LED  //Green
+#define ALT_LED_RADIO_LINK  pin_rssi2LED  //Green
+#define ALT_LED_RSSI        pin_rssi3LED  //Green
+#define ALT_LED_TX_DATA     pin_rssi4LED  //Green
+#define ALT_LED_BAD_FRAMES  pin_txLED     //Blue
+#define ALT_LED_BAD_CRC     pin_rxLED     //Yellow
+
+#define LED_ON              HIGH
+#define LED_OFF             LOW
+
+#define ALT_LED_BLINK_MILLIS    15
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Radio Library
@@ -250,6 +262,13 @@ float frequencyCorrection = 0; //Adjust receive freq based on the last packet re
 
 volatile bool clearDIO1 = true; //Clear the DIO1 hop ISR when possible
 
+//RSSI must be above these negative numbers for LED to illuminate
+const int rssiLevelLow = -150;
+const int rssiLevelMed = -70;
+const int rssiLevelHigh = -50;
+const int rssiLevelMax = -20;
+int rssi; //Signal level
+
 //Link quality metrics
 uint32_t datagramsSent;     //Total number of datagrams sent
 uint32_t datagramsReceived; //Total number of datagrams received
@@ -260,6 +279,7 @@ uint32_t duplicateFrames;   //Total number of duplicate frames received
 uint32_t lostFrames;        //Total number of lost TX frames
 uint32_t linkFailures;      //Total number of link failures
 uint32_t insufficientSpace; //Total number of times the buffer did not have enough space
+uint32_t badCrc;            //Total number of bad CRC frames
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Global variables - V2 Protocol
@@ -405,6 +425,9 @@ void loop()
   updateButton();
 
   updateSerial(); //Store incoming and print outgoing
+
+  if (settings.alternateLedUsage)
+    updateLeds();
 
   updateRadioState(); //Ping/ack/send packets as needed
 

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -735,7 +735,7 @@ PacketType rcvDatagram()
         if (settings.printRfData && rxDataBytes)
             dumpBuffer(incomingBuffer, rxDataBytes);
       }
-      badFrames++;
+      badCrc++;
       return (DATAGRAM_BAD);
     }
   }
@@ -1075,6 +1075,10 @@ PacketType rcvDatagram()
   //Process the packet
   datagramsReceived++;
   linkDownTimer = millis();
+
+  //BLink the RX LED
+  if (settings.alternateLedUsage)
+    digitalWrite(ALT_LED_RX_DATA, LED_ON);
   return datagramType;
 }
 
@@ -1491,6 +1495,10 @@ void retransmitDatagram(VIRTUAL_CIRCUIT * vc)
   }
 
   datagramTimer = millis(); //Move timestamp even if error
+
+  //BLink the RX LED
+  if (settings.alternateLedUsage)
+    digitalWrite(ALT_LED_TX_DATA, LED_ON);
 }
 
 void startChannelTimer()

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -61,6 +61,7 @@ void updateRadioState()
       selectHeaderAndTrailerBytes();
 
       //Initialize the radio
+      rssi = -200;
       radioSeed = radio.randomByte(); //Puts radio into standy-by state
       randomSeed(radioSeed);
       if ((settings.debug == true) || (settings.debugRadio == true))

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -461,6 +461,7 @@ typedef struct struct_settings {
   bool printLinkUpDown = false; //Print the link up and link down messages
   bool invertCts = false; //Invert the input of CTS
   bool invertRts = false; //Invert the output of RTS
+  bool alternateLedUsage = false; //Enable alternate LED usage
 
   //Add new parameters immediately before this line
   //-- Add commands to set the parameters

--- a/Firmware/Tools/Command_Validation_Script.txt
+++ b/Firmware/Tools/Command_Validation_Script.txt
@@ -34,6 +34,7 @@ ati23
 ati24
 ati25
 ati26
+ati27
 ati0
 
 ats28=0
@@ -533,9 +534,15 @@ ats59=2
 ats59=0
 ats59?
 
-# Invalid commands
+# AlternateLedUsage
 ats60=1
+ats60=2
+ats60=0
 ats60?
+
+# Invalid commands
+ats61=1
+ats61?
 
 ats255=1
 ats255?

--- a/Firmware/Tools/Results/Command_Validation_Results.txt
+++ b/Firmware/Tools/Results/Command_Validation_Results.txt
@@ -49,6 +49,7 @@ ati?
   ATI23 - Display the VC link failures
   ATI24 - Display the VC details
   ATI25 - Display the total insufficient buffer count
+  ATI26 - Display the total number of bad CRC frames
 # Allow leading white space (space, tab, cr, lf)
 ERROR
         	ati
@@ -59,35 +60,35 @@ SparkFun LoRaSerial SAMD21 1W 915MHz
 	ati2
 2.0
 ati3
--105
+-4
 ati4
-29
+122
 ati5
 506
 ati6
 37782141A665734E4475672AE6308308
 ati7
-2
+10
 ati8
-FB25B80B5730305020312E50021A0AFF
+E5D60B0B4A34555020312E34212815FF
 ati9
-Total datagrams sent: 36
+Total datagrams sent: 3
 ati10
-Total datagrams received: 34
+Total datagrams received: 1
 ati11
-Total frames sent: 34
+Total frames sent: 1
 ati12
-Total frames sent: 34
+Total frames sent: 1
 ati13
 Total bad frames received: 0
 ati14
 Total duplicate frames received: 0
 ati15
-Total lost TX frames: 201
+Total lost TX frames: 1
 ati16
 Maximum datagram size: 253
 ati17
-Total link failures: 1
+Total link failures: 0
 ati18
 VC 0 frames sent: 0
 ati19
@@ -105,6 +106,8 @@ VC 0: Not valid!
 ati25
 Total insufficient buffer count: 0
 ati26
+Total number of bad CRC frames: 0
+ati27
 ERROR
 ati0
 ATS0:SerialSpeed=57600
@@ -167,6 +170,7 @@ ATS56:TrainingKey=537061726B46756E547261696E696E67
 ATS57:PrintLinkUpDown=0
 ATS58:InvertCts=0
 ATS59:InvertRts=0
+ATS60:AlternateLedUsage=0
 ats28=0
 OK
 # SerialSpeed
@@ -1107,11 +1111,23 @@ InvertRts=0
 OK
 ats59?
 InvertRts=0
-# Invalid commands
+# AlternateLedUsage
 ERROR
 ats60=1
+AlternateLedUsage=1
+OK
+ats60=2
 ERROR
+ats60=0
+AlternateLedUsage=0
+OK
 ats60?
+AlternateLedUsage=0
+# Invalid commands
+ERROR
+ats61=1
+ERROR
+ats61?
 ERROR
 ats255=1
 ERROR
@@ -1119,6 +1135,7 @@ ats255?
 ERROR
 ati0
 ATS1:AirSpeed=4800
+ATS60:AlternateLedUsage=0
 ATS24:AutoTune=0
 ATS13:Bandwidth=500.00
 ATS52:ClientRetryInterval=2


### PR DESCRIPTION
Add badCrc value to count bad CRC frames
Add ATI26 to display the badCrc count
Add ATS60 to select alternate LED usage

rssi1LED - RX radio data
rssi2LED - Radio link up
rssi3LED - RSSI value (pulse width modulated)
rssi4LED - TX radio data
txLED (blue) - Bad frames
rxLED (yellow) - Bad CRC frames