### PR TITLE
Add AT-* commands to support commands by parameter name

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -663,7 +663,7 @@ const COMMAND_ENTRY commands[] =
   {30,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugRadio",           &settings.debugRadio},
   {31,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugStates",          &settings.debugStates},
   {32,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugTraining",        &settings.debugTraining},
-  //33
+  {33,    1, 255,    0, TYPE_U8,           valInt,         "TrainingTimeout",      &settings.trainingTimeout},
   {34,    0,   1,    0, TYPE_BOOL,         valInt,         "UsbSerialWait",        &settings.usbSerialWait},
 
   {35,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintRfData",          &settings.printRfData},

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -663,7 +663,7 @@ const COMMAND_ENTRY commands[] =
   {30,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugRadio",           &settings.debugRadio},
   {31,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugStates",          &settings.debugStates},
   {32,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugTraining",        &settings.debugTraining},
-  {33,    0,   1,    0, TYPE_BOOL,         valInt,         "DebugTrigger",         &settings.debugTrigger},
+  //33
   {34,    0,   1,    0, TYPE_BOOL,         valInt,         "UsbSerialWait",        &settings.usbSerialWait},
 
   {35,    0,   1,    0, TYPE_BOOL,         valInt,         "PrintRfData",          &settings.printRfData},

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -167,8 +167,10 @@ unsigned long lastByteReceived_ms = 0; //Track when last transmission was. Send 
 
 //Global variables - Command Processing
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-char commandBuffer[100]; //Received serial gets stored into buffer until \r or \n is received
-uint8_t commandRXBuffer[100]; //Bytes received from remote, waiting for printing or AT parsing
+#define COMMAND_LENGTH      100
+
+char commandBuffer[COMMAND_LENGTH]; //Received serial gets stored into buffer until \r or \n is received
+uint8_t commandRXBuffer[COMMAND_LENGTH]; //Bytes received from remote, waiting for printing or AT parsing
 uint8_t commandTXBuffer[1024 * 4]; //Bytes waiting to be transmitted to the remote unit
 uint16_t commandTXHead = 0;
 uint16_t commandTXTail = 0;

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -434,6 +434,7 @@ bool trainingPreviousRxInProgress = false; //Previous RX status
 float originalChannel; //Original channel from HOP table while training is in progress
 uint8_t trainingPartnerID[UNIQUE_ID_BYTES]; //Unique ID of the training partner
 uint8_t myUniqueId[UNIQUE_ID_BYTES]; // Unique ID of this system
+unsigned long trainingTimer;
 
 //Virtual-Circuit
 int8_t cmdVc;   //VC index for ATI commands only

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -443,7 +443,6 @@ void updateRadioParameters(uint8_t * rxData)
     originalSettings.debugRadio = params.debugRadio;
     originalSettings.debugStates = params.debugStates;
     originalSettings.debugTraining = params.debugTraining;
-    originalSettings.debugTrigger = params.debugTrigger;
     originalSettings.printRfData = params.printRfData;
     originalSettings.printPktData = params.printPktData;
     originalSettings.debugReceive = params.debugReceive;

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -319,6 +319,10 @@ void triggerEvent(uint8_t triggerNumber)
   uint32_t triggerEnable;
   uint16_t triggerWidth;
 
+  //Determine if the trigger pin is enabled
+  if (pin_trigger != PIN_UNDEFINED)
+    return;
+
   //Determine which trigger enable to use
   triggerBitNumber = triggerNumber;
   triggerEnable = settings.triggerEnable;
@@ -329,24 +333,17 @@ void triggerEvent(uint8_t triggerNumber)
   }
 
   //Determine if the trigger is enabled
-  if ((pin_trigger != PIN_UNDEFINED) && (triggerEnable & (1 << triggerBitNumber)))
+  if (triggerEnable & (1 << triggerBitNumber))
   {
-    //Determine if the trigger pin is enabled
-    if (pin_trigger != PIN_UNDEFINED)
-    {
-      if ((settings.debug == true) || (settings.debugTrigger == true))
-      {
-        //Determine the trigger pulse width
-        triggerWidth = settings.triggerWidth;
-        if (settings.triggerWidthIsMultiplier)
-          triggerWidth *= (triggerNumber + 1);
+    //Determine the trigger pulse width
+    triggerWidth = settings.triggerWidth;
+    if (settings.triggerWidthIsMultiplier)
+      triggerWidth *= (triggerNumber + 1);
 
-        //Output the trigger pulse
-        digitalWrite(pin_trigger, LOW);
-        delayMicroseconds(triggerWidth);
-        digitalWrite(pin_trigger, HIGH);
-      }
-    }
+    //Output the trigger pulse
+    digitalWrite(pin_trigger, LOW);
+    delayMicroseconds(triggerWidth);
+    digitalWrite(pin_trigger, HIGH);
   }
 }
 

--- a/Firmware/LoRaSerial_Firmware/Train.ino
+++ b/Firmware/LoRaSerial_Firmware/Train.ino
@@ -192,7 +192,6 @@ void commonTrainingInitialization()
     settings.debugRadio = originalSettings.debugRadio;
     settings.debugStates = originalSettings.debugStates;
     settings.debugTraining = originalSettings.debugTraining;
-    settings.debugTrigger = originalSettings.debugTrigger;
 
     settings.printRfData = originalSettings.printRfData;
     settings.printPktData = originalSettings.printPktData;

--- a/Firmware/LoRaSerial_Firmware/Train.ino
+++ b/Firmware/LoRaSerial_Firmware/Train.ino
@@ -106,6 +106,7 @@ void beginTrainingPointToPoint(bool defaultTraining)
 
   //Transmit general ping packet to see if anyone else is sitting on the training channel
   xmitDatagramP2PTrainingPing();
+  trainingTimer = millis();
 
   //Set the next state
   changeState(RADIO_P2P_TRAINING_WAIT_PING_DONE);
@@ -131,6 +132,7 @@ void beginTrainingClient()
 
   //Transmit client ping to the training server
   xmitDatagramMpTrainingPing();
+  trainingTimer = millis();
 
   //Set the next state
   changeState(RADIO_MP_WAIT_TX_TRAINING_PING_DONE);

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -428,15 +428,14 @@ typedef struct struct_settings {
   bool debugRadio = false; //Print radio info
   bool debugStates = false; //Print state changes
   bool debugTraining = false; //Print training info
-  bool debugTrigger = false; //Print triggers
   bool usbSerialWait = false; //Wait for USB serial initialization
   bool printRfData = false; //Print RX and TX data
   bool printPktData = false; //Print data, before encryption and after decryption
   bool verifyRxNetID = false; //Verify RX netID value when not operating in point-to-point mode
   uint8_t triggerWidth = 25; //Trigger width in microSeconds or multipler for trigger width
   bool triggerWidthIsMultiplier = true; //Use the trigger width as a multiplier
-  uint32_t triggerEnable = 0xffffffff; //Determine which triggers are enabled: 31 - 0
-  uint32_t triggerEnable2 = 0xffffffff; //Determine which triggers are enabled: 63 - 32
+  uint32_t triggerEnable = 0; //Determine which triggers are enabled: 31 - 0
+  uint32_t triggerEnable2 = 0; //Determine which triggers are enabled: 63 - 32
   bool debugReceive = false; //Print receive processing
   bool debugTransmit = false; //Print transmit processing
   bool printTxErrors = false; //Print any transmit errors

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -391,6 +391,20 @@ typedef struct _CONTROL_U8
   uint8_t filler : 2;
 } CONTROL_U8;
 
+typedef bool (* VALIDATION_ROUTINE)(void * value, uint32_t valMin, uint32_t valMax);
+
+typedef struct _COMMAND_ENTRY
+{
+  uint8_t number;
+  uint32_t minValue;
+  uint32_t maxValue;
+  uint8_t digits;
+  uint8_t type;
+  VALIDATION_ROUTINE validate;
+  const char * name;
+  void * setting;
+} COMMAND_ENTRY;
+
 //These are all the settings that can be set on Serial Terminal Radio. It's recorded to NVM.
 typedef struct struct_settings {
   uint16_t sizeOfSettings = 0; //sizeOfSettings **must** be the first entry and must be int

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -455,6 +455,7 @@ typedef struct struct_settings {
   bool invertCts = false; //Invert the input of CTS
   bool invertRts = false; //Invert the output of RTS
   bool alternateLedUsage = false; //Enable alternate LED usage
+  uint8_t trainingTimeout = 1; //Timeout in minutes to complete the training
 
   //Add new parameters immediately before this line
   //-- Add commands to set the parameters


### PR DESCRIPTION
Example: at-echo=1   or  at-echo?

The parameter name that follows at- is converted to uppercase and compared with the uppercase of the parameter names in the command tables.