### PR TITLE
Add AT-* commands to support commands by parameter name

### DIFF
--- a/Firmware/Tools/Command_Validation_Script.txt
+++ b/Firmware/Tools/Command_Validation_Script.txt
@@ -373,11 +373,11 @@ ats32=0
 ats32?
 at-DebugTraining?
 
-at-DebugTrigger=1
-ats33=2
+at-TrainingTimeout=1
+ats33=255
 ats33=0
 ats33?
-at-DebugTrigger?
+at-TrainingTimeout?
 
 at-UsbSerialWait=1
 ats34=2

--- a/Firmware/Tools/Results/Command_Validation_Results.txt
+++ b/Firmware/Tools/Results/Command_Validation_Results.txt
@@ -64,7 +64,7 @@ SparkFun LoRaSerial SAMD21 1W 915MHz
 ati3
 -157
 ati4
-205
+151
 ati5
 506
 ati6
@@ -74,7 +74,7 @@ ati7
 ati8
 B2A99BF24A34555020312E34162815FF
 ati9
-Total datagrams sent: 678
+Total datagrams sent: 63
 ati10
 Total datagrams received: 0
 ati11
@@ -145,15 +145,15 @@ ATS29:PrintFrequency=0
 ATS30:DebugRadio=0
 ATS31:DebugStates=0
 ATS32:DebugTraining=0
-ATS33:DebugTrigger=0
+ATS33:TrainingTimeout=1
 ATS34:UsbSerialWait=0
 ATS35:PrintRfData=0
 ATS36:PrintPktData=0
 ATS37:VerifyRxNetID=0
 ATS38:TriggerWidth=25
 ATS39:TriggerWidthIsMultiplier=1
-ATS40:TriggerEnable_31-0=-1
-ATS41:TriggerEnable_63-32=-1
+ATS40:TriggerEnable_31-0=0
+ATS41:TriggerEnable_63-32=0
 ATS42:DebugReceive=0
 ATS43:DebugTransmit=0
 ATS44:PrintTxErrors=0
@@ -791,18 +791,18 @@ ats32?
 DebugTraining=0
 at-DebugTraining?
 DebugTraining=0
-at-DebugTrigger=1
-DebugTrigger=1
+at-TrainingTimeout=1
+TrainingTimeout=1
 OK
-ats33=2
-ERROR
+ats33=255
+TrainingTimeout=255
+OK
 ats33=0
-DebugTrigger=0
-OK
+ERROR
 ats33?
-DebugTrigger=0
-at-DebugTrigger?
-DebugTrigger=0
+TrainingTimeout=255
+at-TrainingTimeout?
+TrainingTimeout=255
 at-UsbSerialWait=1
 UsbSerialWait=1
 OK
@@ -1161,7 +1161,6 @@ ATS42:DebugReceive=0
 ATS31:DebugStates=0
 ATS32:DebugTraining=0
 ATS43:DebugTransmit=0
-ATS33:DebugTrigger=0
 ATS25:DisplayPacketQuality=0
 ATS50:DisplayRealMillis=0
 ATS21:Echo=0
@@ -1197,6 +1196,7 @@ ATS14:SpreadFactor=9
 ATS16:SyncWord=18
 ATS56:TrainingKey=01020304050607080910111213141516
 ATS51:TrainingServer=0
+ATS33:TrainingTimeout=255
 ATS40:TriggerEnable_31-0=-1
 ATS41:TriggerEnable_63-32=-1
 ATS38:TriggerWidth=25


### PR DESCRIPTION
Example: at-echo=1   or  at-echo?

The parameter name that follows at- is converted to uppercase and compared with the uppercase of the parameter names in the command tables.