### PR TITLE
Place output data into serialTransmitBuffer

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_ESP32.h
@@ -87,11 +87,6 @@ void esp32SerialFlush()
   Serial.flush();
 }
 
-void esp32SerialPrint(const char * value)
-{
-  Serial.print(value);
-}
-
 uint8_t esp32SerialRead()
 {
   return (Serial.read());
@@ -123,7 +118,6 @@ const ARCH_TABLE arch = {
   esp32Radio,               //radio
   esp32SerialAvailable,     //serialAvailable
   esp32SerialFlush,         //serialFlush
-  esp32SerialPrint,         //serialPrint
   esp32SerialRead,          //serialRead
   esp32SerialWrite,         //serialWrite
   esp32SystemReset,         //systemReset

--- a/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
+++ b/Firmware/LoRaSerial_Firmware/Arch_SAMD.h
@@ -181,12 +181,6 @@ void samdSerialFlush()
   Serial1.flush();
 }
 
-void samdSerialPrint(const char * value)
-{
-  Serial.print(value);
-  Serial1.print(value);
-}
-
 uint8_t samdSerialRead()
 {
   byte incoming = 0;
@@ -231,7 +225,6 @@ const ARCH_TABLE arch = {
   samdRadio,                  //radio
   samdSerialAvailable,        //serialAvailable
   samdSerialFlush,            //serialFlush
-  samdSerialPrint,            //serialPrint
   samdSerialRead,             //serialRead
   samdSerialWrite,            //serialWrite
   samdSystemReset,            //systemReset

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -129,6 +129,7 @@ bool commandAT(const char * commandString)
         break;
       case ('Z'): //Reboots the radio
         reportOK();
+        outputSerialData(true);
         systemFlush();
         systemReset();
         break;

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -474,6 +474,7 @@ void setup()
 
   systemPrintTimestamp();
   systemPrintln("LRS");
+  outputSerialData(true);
 
   verifyRadioStateTable(); //Verify that the state table contains all of the states in increasing order
 
@@ -495,6 +496,7 @@ void setup()
 
   systemPrintTimestamp();
   systemPrintln("LRS Setup Complete");
+  outputSerialData(true);
 
   triggerEvent(TRIGGER_RADIO_RESET);
 }

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -924,7 +924,7 @@ PacketType rcvDatagram()
         }
 
         //Verify that there is sufficient space in the serialTransmitBuffer
-        if ((sizeof(serialTransmitBuffer) - availableTXBytes()) < rxDataBytes)
+        if (inCommandMode || ((sizeof(serialTransmitBuffer) - availableTXBytes()) < rxDataBytes))
         {
           if (settings.debugReceive)
           {

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -1,15 +1,19 @@
-void systemPrint(const char* value)
+void systemPrint(const char* string)
 {
+  uint16_t length;
+
+  length = strlen(string);
   if (printerEndpoint == PRINT_TO_SERIAL)
   {
-    arch.serialPrint(value);
+    for (uint16_t x = 0 ; x < length ; x++)
+      serialOutputByte(string[x]);
   }
   else if (printerEndpoint == PRINT_TO_RF)
   {
     //Move these characters into the transmit buffer
-    for (uint16_t x = 0 ; x < strlen(value) ; x++)
+    for (uint16_t x = 0 ; x < length ; x++)
     {
-      commandTXBuffer[commandTXHead++] = value[x];
+      commandTXBuffer[commandTXHead++] = string[x];
       commandTXHead %= sizeof(commandTXBuffer);
     }
   }
@@ -187,7 +191,7 @@ void systemPrintUniqueID(uint8_t * uniqueID)
 
 void systemWrite(uint8_t value)
 {
-  arch.serialWrite(value);
+  serialOutputByte(value);
 }
 
 void systemWrite(uint8_t * buffer, uint16_t length)

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -422,7 +422,6 @@ typedef void (* ARCH_PET_WDT)();
 typedef Module * (* ARCH_RADIO)();
 typedef bool (* ARCH_SERIAL_AVAILABLE)();
 typedef void (* ARCH_SERIAL_FLUSH)();
-typedef void (* ARCH_SERIAL_PRINT)(const char * value);
 typedef uint8_t (* ARCH_SERIAL_READ)();
 typedef void (* ARCH_SERIAL_WRITE)(uint8_t value);
 typedef void (* ARCH_SYSTEM_RESET)();
@@ -439,7 +438,6 @@ typedef struct _ARCH_TABLE
   ARCH_RADIO radio;               //Initialize the radio
   ARCH_SERIAL_AVAILABLE serialAvailable;  //Determine if serial data is available
   ARCH_SERIAL_FLUSH serialFlush;  //Flush the serial port
-  ARCH_SERIAL_PRINT serialPrint;  //Print the specified string value
   ARCH_SERIAL_READ serialRead;    //Read a byte from the serial port
   ARCH_SERIAL_WRITE serialWrite;  //Print the specified character
   ARCH_SYSTEM_RESET systemReset;  //Reset the system

--- a/Firmware/Tools/Results/Command_Validation_Results.txt
+++ b/Firmware/Tools/Results/Command_Validation_Results.txt
@@ -64,7 +64,7 @@ SparkFun LoRaSerial SAMD21 1W 915MHz
 ati3
 -157
 ati4
-151
+44
 ati5
 506
 ati6
@@ -74,7 +74,7 @@ ati7
 ati8
 B2A99BF24A34555020312E34162815FF
 ati9
-Total datagrams sent: 63
+Total datagrams sent: 70
 ati10
 Total datagrams received: 0
 ati11


### PR DESCRIPTION
This change includes:
* Remove arch.serialPrint
* Add serialOutputByte called by systemPrint and systemWrite to place data into serialTransmitBuffer
* Add outputSerialData to remove bytes from serialTransmitBuffer and write them to the serial port
* Add a few calls to outputSerialData to force serial output
* Don't receive data when in command mode

Verified using:
* States.ino over the radio link
* Command_Validation_Script.txt
