### PR TITLE
Update the debugging for VCs

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -191,6 +191,7 @@ bool commandAT(const char * commandString)
         systemPrintln("  ATI25 - Display the total insufficient buffer count");
         systemPrintln("  ATI26 - Display the total number of bad CRC frames");
         systemPrintln("  ATI27 - Display the total number of net ID mismatch frames");
+        systemPrintln("  ATI28 - Return myVc value");
         break;
       case ('0'): //ATI0 - Show user settable parameters
         displayParameters(0, true);
@@ -366,6 +367,12 @@ bool commandAT(const char * commandString)
       case ('7'): //ATI27 - Display the total number of net ID mismatch frames
         systemPrint("Total number of net ID mismatch frames: ");
         systemPrintln(netIdMismatch);
+        break;
+      case ('8'): //ATI28 - Return myVc value
+        systemPrintln();
+        systemPrint("myVc: ");
+        systemPrintln(myVc);
+        reportOK();
         break;
     }
   }

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -383,38 +383,6 @@ unsigned long datagramTimer;
 uint16_t pingRandomTime;
 uint16_t heartbeatRandomTime;
 
-/* ACK Number Management
-
-            System A                              System B
-
-           txAckNumber
-                |
-                V
-          Tx DATA Frame -----------------------> Rx DATA Frame
-                                                      |
-                                                      V
-                                                  AckNumber == rmtTxAckNumber
-                                                      |
-                                                      | yes
-                                                      V
-                                                 rxAckNumber = rmtTxAckNumber++
-                                                      |
-                                                      V
-        Rx DATA_Ack Frame <--------------------- Tx DATA_ACK Frame
-                |
-                V
-            ackNumber == txAckNumber
-                |
-                | yes
-                V
-           txAckNumber++
-*/
-
-//ACK management
-uint8_t rmtTxAckNumber;
-uint8_t rxAckNumber;
-uint8_t txAckNumber;
-
 //Receive control
 uint8_t incomingBuffer[MAX_PACKET_SIZE];
 uint8_t minDatagramSize;

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -643,6 +643,32 @@ bool xmitVcHeartbeat(int8_t addr, uint8_t * id)
   return (transmitDatagram());
 }
 
+//Build the ACK frame
+bool xmitVcAckFrame(int8_t destVc)
+{
+  VC_RADIO_MESSAGE_HEADER * vcHeader;
+
+  vcHeader = (VC_RADIO_MESSAGE_HEADER *)endOfTxData;
+  vcHeader->length = VC_RADIO_HEADER_BYTES + CLOCK_SYNC_BYTES;
+  vcHeader->destVc = destVc;
+  vcHeader->srcVc = myVc;
+  endOfTxData += VC_RADIO_HEADER_BYTES;
+
+  /*
+                                        endOfTxData ---.
+                                                       |
+                                                       V
+      +--------+---------+--------+----------+---------+----------+----------+
+      |        |         |        |          |         | Channel  | Optional |
+      | NET ID | Control | Length | DestAddr | SrcAddr |  Timer   | Trailer  |
+      | 8 bits | 8 bits  | 8 bits |  8 bits  | 8 bits  | 2 bytes  | n Bytes  |
+      +--------+---------+--------+----------+---------+----------+----------+
+  */
+
+  //Finish building the ACK frame
+  return xmitDatagramP2PAck();
+}
+
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 //Datagram reception
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -657,6 +657,9 @@ PacketType rcvDatagram()
   VIRTUAL_CIRCUIT * vc;
   VC_RADIO_MESSAGE_HEADER * vcHeader;
 
+  //Acknowledge the receive interrupt
+  transactionComplete = false;
+
   //Save the receive time
   rcvTimeMillis = millis();
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1606,15 +1606,18 @@ void updateRadioState()
 
           case DATAGRAM_DATA:
             //Move the data into the serial output buffer
+            if (settings.debugSerial)
+            {
+              systemPrint("updateRadioState moving ");
+              systemPrint(rxDataBytes);
+              systemPrintln(" bytes from inputBuffer into serialTransmitBuffer");
+              outputSerialData(true);
+            }
+            systemWrite(START_OF_VC_SERIAL);
             serialBufferOutput(rxData, rxDataBytes);
 
             //Acknowledge the data frame
-            vcHeader = (VC_RADIO_MESSAGE_HEADER *)endOfTxData;
-            vcHeader->length = VC_RADIO_HEADER_BYTES + CLOCK_SYNC_BYTES;
-            vcHeader->destVc = rxSrcVc;
-            vcHeader->srcVc = myVc;
-            endOfTxData += VC_RADIO_HEADER_BYTES;
-            if (xmitDatagramP2PAck() == true)
+            if (xmitVcAckFrame(rxSrcVc))
               changeState(RADIO_VC_WAIT_TX_DONE);
             break;
 
@@ -1708,15 +1711,18 @@ void updateRadioState()
 
           case DATAGRAM_DATA:
             //Move the data into the serial output buffer
+            if (settings.debugSerial)
+            {
+              systemPrint("updateRadioState moving ");
+              systemPrint(rxDataBytes);
+              systemPrintln(" bytes from inputBuffer into serialTransmitBuffer");
+              outputSerialData(true);
+            }
+            systemWrite(START_OF_VC_SERIAL);
             serialBufferOutput(rxData, rxDataBytes);
 
             //Acknowledge the data frame
-            vcHeader = (VC_RADIO_MESSAGE_HEADER *)endOfTxData;
-            vcHeader->length = VC_RADIO_HEADER_BYTES + CLOCK_SYNC_BYTES;
-            vcHeader->destVc = rxSrcVc;
-            vcHeader->srcVc = myVc;
-            endOfTxData += VC_RADIO_HEADER_BYTES;
-            if (xmitDatagramP2PAck() == true)
+            if (xmitVcAckFrame(rxSrcVc))
               changeState(RADIO_VC_WAIT_TX_DONE_ACK);
             break;
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -2132,6 +2132,8 @@ void v2BreakLink()
 
 void v2EnterLinkUp()
 {
+  VIRTUAL_CIRCUIT * vc;
+
   //Bring up the link
   triggerEvent(TRIGGER_HANDSHAKE_COMPLETE);
   hopChannel(); //Leave home
@@ -2139,9 +2141,10 @@ void v2EnterLinkUp()
   updateRSSI();
 
   //Synchronize the ACK numbers
-  rmtTxAckNumber = 0;
-  rxAckNumber = 0;
-  txAckNumber = 0;
+  vc = &virtualCircuitList[0];
+  vc->rmtTxAckNumber = 0;
+  vc->rxAckNumber = 0;
+  vc->txAckNumber = 0;
 
   //Discard any previous data
   discardPreviousData();

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -189,8 +189,6 @@ void updateRadioState()
       //Determine if a PING was received
       if (transactionComplete)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received packet
         PacketType packetType = rcvDatagram();
 
@@ -265,8 +263,6 @@ void updateRadioState()
     case RADIO_P2P_WAIT_ACK_1:
       if (transactionComplete)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received packet
         PacketType packetType = rcvDatagram();
 
@@ -376,8 +372,6 @@ void updateRadioState()
     case RADIO_P2P_WAIT_ACK_2:
       if (transactionComplete == true)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received packet
         PacketType packetType = rcvDatagram();
 
@@ -537,8 +531,6 @@ void updateRadioState()
       //Check for a received datagram
       if (transactionComplete == true)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received datagram
         PacketType packetType = rcvDatagram();
 
@@ -778,8 +770,6 @@ void updateRadioState()
 
       if (transactionComplete)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received datagram
         PacketType packetType = rcvDatagram();
 
@@ -1027,8 +1017,6 @@ void updateRadioState()
 
       if (transactionComplete)
       {
-        transactionComplete = false; //Reset ISR flag
-
         //Decode the received datagram
         PacketType packetType = rcvDatagram();
 
@@ -1158,7 +1146,6 @@ void updateRadioState()
       if (transactionComplete == true)
       {
         triggerEvent(TRIGGER_MP_PACKET_RECEIVED);
-        transactionComplete = false; //Reset ISR flag
 
         //Decode the received datagram
         PacketType packetType = rcvDatagram();
@@ -1382,7 +1369,6 @@ void updateRadioState()
       //If dio0ISR has fired, a packet has arrived
       if (transactionComplete == true)
       {
-        transactionComplete = false;
         trainingPreviousRxInProgress = false;
 
         //Decode the received datagram
@@ -1483,7 +1469,6 @@ void updateRadioState()
       //If dio0ISR has fired, a packet has arrived
       if (transactionComplete == true)
       {
-        transactionComplete = false; //Reset ISR flag
         trainingPreviousRxInProgress = false;
 
         //Decode the received datagram
@@ -1603,7 +1588,6 @@ void updateRadioState()
       currentMillis = millis();
       if (transactionComplete == true)
       {
-        transactionComplete = false; //Reset ISR flag
         trainingPreviousRxInProgress = false;
 
         //Decode the received datagram
@@ -1706,7 +1690,6 @@ void updateRadioState()
       currentMillis = millis();
       if (transactionComplete == true)
       {
-        transactionComplete = false; //Reset ISR flag
         trainingPreviousRxInProgress = false;
 
         //Decode the received datagram


### PR DESCRIPTION
This check-in includes the following changes:
* Always increment badFrames before returning DATAGRAM_BAD
* Display SF6 length during receive
* Display the VC header during receive
* Summarize the VC communication
* Display the VC ACK number