### PR TITLE
VC: Remote command support any VC to any VC

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -463,6 +463,10 @@ void checkCommand()
     || (commandString[commandLength -1] == '\n')))
     commandLength -= 1;
 
+  //Upper case the command
+  for (index = 0; index < commandLength; index++)
+    commandBuffer[index] = toupper(commandBuffer[index]);
+
   commandString[commandLength] = '\0'; //Terminate buffer
   if (commandLength < 2) //Too short
     reportERROR();

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -329,7 +329,6 @@ unsigned long lastTrainBlink = 0; //Controls LED during training
 //Global variables - Radio (General)
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 uint8_t outgoingPacket[MAX_PACKET_SIZE]; //Contains the current data in route to receiver
-uint8_t packetSize = 0; //Tracks how much data + control trailer
 uint16_t frameAirTime = 0; //Recalc'd with each new packet transmission
 uint16_t ackAirTime = 0; //Recalc'd with each change of settings
 uint8_t frameSentCount = 0; //Increases each time a frame is sent

--- a/Firmware/LoRaSerial_Firmware/RadioV2.ino
+++ b/Firmware/LoRaSerial_Firmware/RadioV2.ino
@@ -1224,9 +1224,9 @@ PacketType rcvDatagram()
     systemPrint("RX: ");
     if (settings.operatingMode == MODE_VIRTUAL_CIRCUIT)
     {
-      systemPrint((uint8_t)rxDestVc);
+      systemPrint((uint8_t)((rxDestVc == VC_BROADCAST) ? rxDestVc : rxDestVc & VCAB_NUMBER_MASK));
       systemPrint(" <-- ");
-      systemPrint((uint8_t)rxSrcVc);
+      systemPrint((uint8_t)((rxSrcVc == VC_UNASSIGNED) ? rxSrcVc : rxSrcVc & VCAB_NUMBER_MASK));
       systemWrite(' ');
     }
     systemPrint(v2DatagramType[datagramType]);
@@ -1399,9 +1399,9 @@ bool transmitDatagram()
     systemPrint("TX: ");
     if (settings.operatingMode == MODE_VIRTUAL_CIRCUIT)
     {
-      systemPrint((uint8_t)srcVc);
+      systemPrint((uint8_t)((srcVc == VC_UNASSIGNED) ? srcVc : srcVc & VCAB_NUMBER_MASK));
       systemPrint(" --> ");
-      systemPrint((uint8_t)txDestVc);
+      systemPrint((uint8_t)((txDestVc == VC_BROADCAST) ? txDestVc : txDestVc & VCAB_NUMBER_MASK));
       systemWrite(' ');
     }
     systemPrint(v2DatagramType[txControl.datagramType]);
@@ -1792,6 +1792,7 @@ bool retransmitDatagram(VIRTUAL_CIRCUIT * vc)
     triggerEvent(TRIGGER_TRANSMIT_CANCELED);
     if (settings.debugReceive || settings.debugDatagrams)
     {
+      systemPrint("TX failed: ");
       if (transactionComplete)
         systemPrintln("RXTC");
       else if (receiveInProcess())

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -515,6 +515,25 @@ bool vcSerialMessageReceived()
       break;
     }
 
+    //Verify that the destination link is up
+    if ((vcDest != VC_BROADCAST)
+      && (virtualCircuitList[vcDest & VCAB_NUMBER_MASK].linkUp == false))
+    {
+      if (settings.debugSerial || settings.debugTransmit)
+      {
+        systemPrint("Link down ");
+        systemPrint((vcDest == VC_BROADCAST) ? vcDest : vcDest & VCAB_NUMBER_MASK);
+        systemPrintln(", discarding message!");
+        outputSerialData(true);
+      }
+
+      //Discard this message
+      radioTxTail += msgLength;
+      if (radioTxTail >= sizeof(radioTxBuffer))
+        radioTxTail -= sizeof(radioTxBuffer);
+      break;
+    }
+
     //Print the data ready for transmission
     if (settings.debugSerial)
     {

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -327,7 +327,7 @@ void processSerialInput()
         else
         {
           //Move this character into the command buffer
-          commandBuffer[commandLength++] = toupper(incoming);
+          commandBuffer[commandLength++] = incoming;
           commandLength %= sizeof(commandBuffer);
         }
       }

--- a/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
+++ b/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
@@ -143,5 +143,6 @@ typedef struct _VC_LINK_STATUS_MESSAGE
 
 #define DATA_BYTES(vc_message_length)     (vc_message_length - VC_RADIO_HEADER_BYTES)
 #define DATA_BUFFER(data)                 (data + VC_RADIO_HEADER_BYTES)
+#define GET_CHANNEL_NUMBER(vc)            (vc & (VCAB_CHANNEL_MASK << VCAB_NUMBER_BITS))
 
 #endif  //__VIRTUAL_CIRCUIT_PROTOCOL_H__

--- a/Firmware/Tools/VcServerTest.c
+++ b/Firmware/Tools/VcServerTest.c
@@ -336,17 +336,17 @@ int radioToHost()
     }
 
     //Process the message
-    switch (header->radio.destVc)
+    if (header->radio.destVc == PC_LINK_STATUS)
+      radioToPcLinkStatus(header, VC_SERIAL_HEADER_BYTES + length);
+
+    if (header->radio.destVc == (PC_REMOTE_RESPONSE | myVc))
+        status = hostToStdout(data, length);
+
+    else
     {
-    default:
       if ((header->radio.destVc == myVc) || (header->radio.destVc == VC_BROADCAST))
         //Output this message
         status = hostToStdout(data, length);
-      break;
-
-    case PC_LINK_STATUS:
-      radioToPcLinkStatus(header, VC_SERIAL_HEADER_BYTES + length);
-      break;
     }
 
     //Continue processing the rest of the data in the buffer
@@ -399,7 +399,7 @@ main (
 
     //Determine the remote VC address
     if ((sscanf(argv[2], "%d", &remoteVc) != 1)
-      || (remoteVc < VC_COMMAND) || (remoteVc >= MAX_VC))
+      || ((remoteVc > PC_LINK_STATUS) && (remoteVc < VC_COMMAND)))
     {
       fprintf(stderr, "ERROR: Invalid target VC address, please use one of the following:\n");
       if (myVc)


### PR DESCRIPTION
This commit includes the following changes:
* Modify serial to pass remote commands to the transmit code
* Modify radio code to display the proper VC numbers
* Leave all remote commands in the outgoingPacket
* Process the remote command locally
    *  Place response in commandTXBuffer
    * Divide up response and place in serialTransmitBuffer
* Place the remote command into the command buffer and process it
* Transmit command response to VC that issued the command
* Receive the command response
