### PR TITLE
P2P: Simplify the state machine

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -686,18 +686,11 @@ void checkCommand()
 
   //Verify the command length
   success = false;
-  commandString = trimCommand(); //Remove any leading whitespace
-
-  //Remove trailing CR and LF
-  while ((commandLength > 0) && ((commandString[commandLength - 1] == '\r')
-                                 || (commandString[commandLength - 1] == '\n')))
-    commandLength -= 1;
+  commandString = trimCommand(); //Remove any leading or trailing whitespace
 
   //Upper case the command
   for (index = 0; index < commandLength; index++)
-    commandBuffer[index] = toupper(commandBuffer[index]);
-
-  commandString[commandLength] = '\0'; //Terminate buffer
+    commandString[index] = toupper(commandString[index]);
 
   //Verify the command length
   if (commandLength >= 2)
@@ -739,11 +732,21 @@ char * trimCommand()
 {
   char * commandString = commandBuffer;
 
+  //Remove the leading white space
   while (isspace(*commandString))
   {
     commandString++;
-    commandLength--;
+    --commandLength;
   }
+
+  //Zero terminate the string
+  commandString[commandLength] = 0;
+
+  //Remove the trailing white space
+  while (commandLength && isspace(commandString[commandLength -1]))
+    commandString[--commandLength] = 0;
+
+  //Return the remainder as the command
   return commandString;
 }
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -168,6 +168,7 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('T'): //ATT - Enter training mode
+        settings = tempSettings; //Apply user's modifications
         selectTraining();
         return true;
 

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -681,22 +681,7 @@ void radioLeds()
   }
 
   //Update the link LED
-  switch (radioState)
-  {
-    //Turn off the LED
-    default:
-      digitalWrite(RADIO_USE_LINK_LED, LED_OFF);
-      break;
-
-    //Turn on the LED
-    case RADIO_P2P_LINK_UP:
-    case RADIO_P2P_LINK_UP_WAIT_ACK_DONE:
-    case RADIO_P2P_LINK_UP_WAIT_TX_DONE:
-    case RADIO_P2P_LINK_UP_WAIT_ACK:
-    case RADIO_P2P_LINK_UP_HB_ACK_REXMT:
-      digitalWrite(RADIO_USE_LINK_LED, LED_ON);
-      break;
-  }
+  digitalWrite(RADIO_USE_LINK_LED, isLinked() ? LED_ON : LED_OFF);
 
   //Update the RSSI LED
   if (currentMillis != previousMillis)

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -12,10 +12,7 @@ typedef enum
 
   //Point-to-Point: Link up, data exchange
   RADIO_P2P_LINK_UP,
-  RADIO_P2P_LINK_UP_WAIT_ACK_DONE,
   RADIO_P2P_LINK_UP_WAIT_TX_DONE,
-  RADIO_P2P_LINK_UP_WAIT_ACK,
-  RADIO_P2P_LINK_UP_HB_ACK_REXMT,
 
   //Server-client discovery
   RADIO_DISCOVER_BEGIN,
@@ -71,38 +68,35 @@ const RADIO_STATE_ENTRY radioStateTable[] =
   //Point-to-Point, link up, data exchange
   //    State                           RX      Name                              Description
   {RADIO_P2P_LINK_UP,                    1, "P2P_LINK_UP",                    "P2P: Receiving Standby"},          //10
-  {RADIO_P2P_LINK_UP_WAIT_ACK_DONE,      0, "P2P_LINK_UP_WAIT_ACK_DONE",      "P2P: Waiting ACK TX Done"},        //11
-  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            //12
-  {RADIO_P2P_LINK_UP_WAIT_ACK,           1, "P2P_LINK_UP_WAIT_ACK",           "P2P: Waiting for ACK"},            //13
-  {RADIO_P2P_LINK_UP_HB_ACK_REXMT,       0, "P2P_LINK_UP_HB_ACK_REXMT",       "P2P: Heartbeat ACK ReXmt"},        //14
+  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            //11
 
   //Server-client discovery
   //    State                           RX      Name                              Description
-  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        //15
-  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //16
-  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //17
+  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        //12
+  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //13
+  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //14
 
   //Multi-Point data exchange
   //    State                           RX      Name                              Description
-  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //18
-  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //19
-  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //20
+  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //15
+  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //16
+  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //17
 
   //Training client states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //21
-  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //22
-  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //23
+  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //18
+  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //19
+  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //20
 
   //Training server states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //24
-  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //25
+  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //21
+  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //22
 
   //Virtual circuit states
   //    State                           RX      Name                              Description
-  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //27
-  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //28
+  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //23
+  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //24
 };
 
 //Possible types of packets received


### PR DESCRIPTION
This commit makes the following changes:
* Reduces the number of states in the P2P link-up state machine
* Prioritizes transmit operations
    * Heartbeats
    * ACKs
    * Send remote commands and responses
    * Send data
* Link kept alive even when maxResends = 0