### PR TITLE
Fix the macro that sets the ackTimer

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -1037,7 +1037,7 @@ const COMMAND_ENTRY commands[] =
 
   /*Training parameters
     Ltr, All, reset, min, max, digits,    type,         validation,     name,                   setting addr */
-  {'R',   0,   1,    1, 255,    0, TYPE_U8,           valInt,      "ClientPingRetryInterval", &tempSettings.clientPingRetryInterval},
+  {'R',   0,   1,    1, 255,    0, TYPE_U8,           valInt,"ClientFindPartnerRetryInterval",&tempSettings.clientFindPartnerRetryInterval},
   {'R',   0,   0,    0,   0,    0, TYPE_KEY,          valKey,         "TrainingKey",          &tempSettings.trainingKey},
   {'R',   0,   0,    1, 255,    0, TYPE_U8,           valInt,         "TrainingTimeout",      &tempSettings.trainingTimeout},
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -542,7 +542,7 @@ bool commandAT(const char * commandString)
         systemPrint("VC ");
         systemPrint(cmdVc);
         systemPrint(": ");
-        if (!vc->valid)
+        if (!vc->flags.valid)
         {
           systemPrint("Down, Not valid @ ");
           systemPrintTimestamp(millis());
@@ -556,7 +556,7 @@ bool commandAT(const char * commandString)
           systemPrintln();
           systemPrint("    ID: ");
           systemPrintUniqueID(vc->uniqueId);
-          systemPrintln(vc->valid ? " (Valid)" : " (Invalid)");
+          systemPrintln(vc->flags.valid ? " (Valid)" : " (Invalid)");
 
           //Heartbeat metrics
           systemPrintln("    Heartbeats");

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -193,6 +193,14 @@ bool commandAT(const char * commandString)
         }
 
         reportOK();
+        if (serialOperatingMode == MODE_VIRTUAL_CIRCUIT)
+        {
+          //Notify the PC of the serial port failure
+          serialOutputByte(START_OF_VC_SERIAL);
+          serialOutputByte(3);
+          serialOutputByte(PC_SERIAL_RECONNECT);
+          serialOutputByte(myVc);
+        }
         outputSerialData(true);
         systemFlush();
         systemReset();

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -159,16 +159,24 @@ bool commandAT(const char * commandString)
 
         settings = tempSettings; //Apply user's modifications
 
-        if (writeOnCommandExit) recordSystemSettings();
+        if (writeOnCommandExit)
+        {
+          writeOnCommandExit = false;
+          recordSystemSettings();
+        }
 
         //If a setting was applied that requires radio reset, do so
         if (forceRadioReset)
+        {
+          forceRadioReset = false;
           changeState(RADIO_RESET);
+        }
 
         return true;
 
       case ('T'): //ATT - Enter training mode
-        settings = tempSettings; //Apply user's modifications
+        if (inCommandMode)
+          settings = tempSettings; //Apply user's modifications
         selectTraining();
         return true;
 
@@ -179,7 +187,8 @@ bool commandAT(const char * commandString)
       case ('Z'): //ATZ - Reboots the system
         if (writeOnCommandExit)
         {
-          settings = tempSettings; //Apply user's modifications
+          if (inCommandMode)
+            settings = tempSettings; //Apply user's modifications
           recordSystemSettings();
         }
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -122,7 +122,7 @@ bool commandAT(const char * commandString)
         if (cmdVc == myVc)
           vcChangeState(cmdVc, VC_STATE_CONNECTED);
         else
-          vcChangeState(cmdVc, VC_STATE_SEND_PING);
+          vcChangeState(cmdVc, VC_STATE_SEND_UNKNOWN_ACKS);
         return true;
 
       case ('F'): //ATF - Restore default parameters

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -686,18 +686,11 @@ void checkCommand()
 
   //Verify the command length
   success = false;
-  commandString = trimCommand(); //Remove any leading whitespace
-
-  //Remove trailing CR and LF
-  while ((commandLength > 0) && ((commandString[commandLength - 1] == '\r')
-                                 || (commandString[commandLength - 1] == '\n')))
-    commandLength -= 1;
+  commandString = trimCommand(); //Remove any leading or trailing whitespace
 
   //Upper case the command
   for (index = 0; index < commandLength; index++)
-    commandBuffer[index] = toupper(commandBuffer[index]);
-
-  commandString[commandLength] = '\0'; //Terminate buffer
+    commandString[index] = toupper(commandString[index]);
 
   //Verify the command length
   if (commandLength >= 2)
@@ -739,11 +732,21 @@ char * trimCommand()
 {
   char * commandString = commandBuffer;
 
+  //Remove the leading white space
   while (isspace(*commandString))
   {
     commandString++;
-    commandLength--;
+    --commandLength;
   }
+
+  //Zero terminate the string
+  commandString[commandLength] = 0;
+
+  //Remove the trailing white space
+  while (commandLength && isspace(commandString[commandLength -1]))
+    commandString[--commandLength] = 0;
+
+  //Return the remainder as the command
   return commandString;
 }
 

--- a/Firmware/LoRaSerial_Firmware/Commands.ino
+++ b/Firmware/LoRaSerial_Firmware/Commands.ino
@@ -168,6 +168,7 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('T'): //ATT - Enter training mode
+        settings = tempSettings; //Apply user's modifications
         selectTraining();
         return true;
 

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -431,7 +431,7 @@ uint8_t txDatagramSize;
 
 //Point-to-Point
 unsigned long datagramTimer;
-uint16_t pingRandomTime;
+uint16_t randomTime;
 uint16_t heartbeatRandomTime;
 
 //Receive control

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -563,7 +563,7 @@ void loop()
 
   updateSerial(); //Store incoming and print outgoing
 
-  updateRadioState(); //Ping/ack/send packets as needed
+  updateRadioState(); //Send packets as needed for handshake, data, remote commands
 
   updateLeds(); //Update the LEDs on the board
 

--- a/Firmware/LoRaSerial_Firmware/NVM.ino
+++ b/Firmware/LoRaSerial_Firmware/NVM.ino
@@ -137,7 +137,7 @@ void nvmLoadVcUniqueId(int8_t vc)
     {
       //The unique ID was set, copy it into the VC structure
       memcpy(virtualCircuitList[vc].uniqueId, id, sizeof(id));
-      virtualCircuitList[vc].valid = true;
+      virtualCircuitList[vc].flags.valid = true;
       break;
     }
   }

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -732,9 +732,9 @@ const uint16_t crc16Table[256] =
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 //First packet in the three way handshake to bring up the link
-bool xmitDatagramP2PPing()
+bool xmitDatagramP2PFindPartner()
 {
-  radioCallHistory[RADIO_CALL_xmitDatagramP2PPing] = millis();
+  radioCallHistory[RADIO_CALL_xmitDatagramP2PFindPartner] = millis();
 
   unsigned long currentMillis = millis();
   memcpy(endOfTxData, &currentMillis, sizeof(currentMillis));
@@ -751,7 +751,7 @@ bool xmitDatagramP2PPing()
       +----------+---------+----------+------------+---------+----------+
   */
 
-  txControl.datagramType = DATAGRAM_PING;
+  txControl.datagramType = DATAGRAM_FIND_PARTNER;
   return (transmitDatagram());
 }
 
@@ -1005,7 +1005,7 @@ bool xmitDatagramMpPing()
       +----------+---------+----------+------------+----------+
   */
 
-  txControl.datagramType = DATAGRAM_PING;
+  txControl.datagramType = DATAGRAM_FIND_PARTNER;
   return (transmitDatagram());
 }
 
@@ -2347,7 +2347,7 @@ bool transmitDatagram()
         txDatagramSize = MAX_PACKET_SIZE - trailerBytes; //We're now going to transmit a full size datagram
         break;
 
-      case DATAGRAM_PING:
+      case DATAGRAM_FIND_PARTNER:
       case DATAGRAM_ACK_1:
       case DATAGRAM_ACK_2:
         txDatagramSize = headerBytes + CLOCK_MILLIS_BYTES; //Short packet is 5 + 4
@@ -3054,7 +3054,7 @@ const I16_TO_STRING radioCallName[] =
   {RADIO_CALL_calcAirTime, "calcAirTime"},
   {RADIO_CALL_xmitDatagramP2PTrainingPing, "xmitDatagramP2PTrainingPing"},
   {RADIO_CALL_xmitDatagramP2pTrainingParams, "xmitDatagramP2pTrainingParams"},
-  {RADIO_CALL_xmitDatagramP2PPing, "xmitDatagramP2PPing"},
+  {RADIO_CALL_xmitDatagramP2PFindPartner, "xmitDatagramP2PFindPartner"},
   {RADIO_CALL_xmitDatagramP2PAck1, "xmitDatagramP2PAck1"},
   {RADIO_CALL_xmitDatagramP2PAck2, "xmitDatagramP2PAck2"},
   {RADIO_CALL_xmitDatagramP2PCommand, "xmitDatagramP2PCommand"},

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -1013,10 +1013,10 @@ bool xmitDatagramMpPing()
 //Multi-Point Client Training
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-//Build the client ping packet used for training
-bool xmitDatagramTrainingPing()
+//Build the FIND_PARTNER packet used for training
+bool xmitDatagramTrainingFindPartner()
 {
-  radioCallHistory[RADIO_CALL_xmitDatagramTrainingPing] = millis();
+  radioCallHistory[RADIO_CALL_xmitDatagramTrainingFindPartner] = millis();
 
   //Add the source (server) ID
   memcpy(endOfTxData, myUniqueId, UNIQUE_ID_BYTES);
@@ -1033,7 +1033,7 @@ bool xmitDatagramTrainingPing()
       +----------+---------+----------+------------+-----------+----------+
   */
 
-  txControl.datagramType = DATAGRAM_TRAINING_PING;
+  txControl.datagramType = DATAGRAM_TRAINING_FIND_PARTNER;
   return (transmitDatagram());
 }
 
@@ -3052,8 +3052,6 @@ const I16_TO_STRING radioCallName[] =
   {RADIO_CALL_setRadioFrequency, "setRadioFrequency"},
   {RADIO_CALL_returnToReceiving, "returnToReceiving"},
   {RADIO_CALL_calcAirTime, "calcAirTime"},
-  {RADIO_CALL_xmitDatagramP2PTrainingPing, "xmitDatagramP2PTrainingPing"},
-  {RADIO_CALL_xmitDatagramP2pTrainingParams, "xmitDatagramP2pTrainingParams"},
   {RADIO_CALL_xmitDatagramP2PFindPartner, "xmitDatagramP2PFindPartner"},
   {RADIO_CALL_xmitDatagramP2PAck1, "xmitDatagramP2PAck1"},
   {RADIO_CALL_xmitDatagramP2PAck2, "xmitDatagramP2PAck2"},
@@ -3066,7 +3064,7 @@ const I16_TO_STRING radioCallName[] =
   {RADIO_CALL_xmitDatagramMpHeartbeat, "xmitDatagramMpHeartbeat"},
   {RADIO_CALL_xmitDatagramMpAck, "xmitDatagramMpAck"},
   {RADIO_CALL_xmitDatagramMpPing, "xmitDatagramMpPing"},
-  {RADIO_CALL_xmitDatagramTrainingPing, "xmitDatagramTrainingPing"},
+  {RADIO_CALL_xmitDatagramTrainingFindPartner, "xmitDatagramTrainingFindPartner"},
   {RADIO_CALL_xmitDatagramTrainingAck, "xmitDatagramTrainingAck"},
   {RADIO_CALL_xmitDatagramTrainRadioParameters, "xmitDatagramTrainRadioParameters"},
   {RADIO_CALL_xmitVcDatagram, "xmitVcDatagram"},

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -678,55 +678,56 @@ const uint16_t crc16Table[256] =
 //Point-To-Point: Bring up the link
 //
 //A three way handshake is used to get both systems to agree that data can flow in both
-//directions.  This handshake is also used to synchronize the HOP timer.
+//directions. This handshake is also used to synchronize the HOP timer and zero the ACKs.
 /*
-                    System A                 System B
+                System A                 System B
 
-                     RESET                     RESET
-                       |                         |
-             Channel 0 |                         | Channel 0
-                       V                         V
-           .----> P2P_NO_LINK               P2P_NO_LINK
-           |           | Tx PING                 |
-           | Timeout   |                         |
-           |           V                         |
-           | P2P_WAIT_TX_PING_DONE               |
-           |           |                         |
-           |           | Tx Complete - - - - - > | Rx PING
-           |           |   Start Rx              |
-           |           |   MAX_PACKET_SIZE       |
-           |           V                         V
-           `---- P2P_WAIT_ACK_1                  +<----------------------.
-                       |                         | Tx PING ACK1          |
-                       |                         V                       |
-                       |              P2P_WAIT_TX_ACK_1_DONE             |
-                       |                         |                       |
-          Rx PING ACK1 | < - - - - - - - - - - - | Tx Complete           |
-                       |                         |   Start Rx            |
-                       |                         |   MAX_PACKET_SIZE     |
-                       |                         |                       |
-                       V                         V         Timeout       |
-           .---------->+                   P2P_WAIT_ACK_2 -------------->+
-           |   TX PING |                         |                       ^
-           |      ACK2 |                         |                       |
-           |           V                         |                       |
-           | P2P_WAIT_TX_ACK_2_DONE              |                       |
-           |           | Tx Complete - - - - - > | Rx PING ACK2          |
-           | Stop      |   Start HOP timer       |   Start HOP Timer     | Stop
-           | HOP       |   Start Rx              |   Start Rx            | HOP
-           | Timer     |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE     | Timer
-           |           |                         |                       |
-           | Rx        |                         |                       |
-           | PING ACK  V                         V         Rx PING       |
-           `----- P2P_LINK_UP               P2P_LINK_UP -----------------’
-                       |                         |
-                       | Rx Data                 | Rx Data
-                       |                         |
-                       V                         V
+                 RESET                     RESET
+                   |                         |
+         Channel 0 |                         | Channel 0
+                   V                         V
+       .----> P2P_NO_LINK               P2P_NO_LINK
+       |           | Tx FIND_PARTNER         |
+       | Timeout   |                         |
+       |           V                         |
+       | P2P_WAIT_TX_FIND_PARTNER_DONE       |
+       |           |                         |
+       |           | Tx Complete - - - - - > | Rx FIND_PARTNER
+       |           |   Start Rx              |
+       |           |   MAX_PACKET_SIZE       |
+       |           V                         V
+       `---- P2P_WAIT_SYNC_CLOCKS            +<----------------------------.
+                   |                         | Tx SYNC_CLOCKS              |
+                   |                         V                             |
+                   |              P2P_WAIT_TX_SYNC_CLOCKS_DONE             |
+                   |                         |                             |
+    Rx SYNC_CLOCKS | < - - - - - - - - - - - | Tx Complete                 |
+                   |                         |   Start Rx                  |
+                   |                         |   MAX_PACKET_SIZE           |
+                   |                         |                             |
+                   V                         V         Timeout             |
+  .--------------->+                P2P_WAIT_ZERO_ACKS ------------------->+
+  |                |                         |                             ^
+  |                | TX ZERO_ACKS            |                             |
+  |                |                         |                             |
+  |                V                         |                             |
+  |    P2P_WAIT_TX_ZERO_ACKS_DONE            |                             |
+  |                | Tx Complete - - - - - > | Rx ZERO_ACKS                |
+  | Stop           |   Start HOP timer       |   Start HOP Timer           | Stop
+  | HOP            |   Start Rx              |   Start Rx                  | HOP
+  | Timer          |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE           | Timer
+  |                |   Zero ACKs             |   Zero ACKs                 |
+  |       Rx       |                         |                             |
+  |    SYNC_CLOCKS V                         V         Rx FIND_PARTNER     |
+  `---------- P2P_LINK_UP               P2P_LINK_UP -----------------------’
+                   |                         |
+                   | Rx Data                 | Rx Data
+                   |                         |
+                   V                         V
 
   Two timers are in use:
     datagramTimer:  Set at end of transmit, measures ACK timeout
-    heartbeatTimer: Set upon entry to P2P_NO_LINK, measures time to send next PING
+    heartbeatTimer: Set upon entry to P2P_NO_LINK, measures time to send next FIND_PARTNER
 */
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -314,7 +314,7 @@ void generateHopTable()
                + settings.verifyRxNetID
                + settings.overheadTime
                + settings.enableCRC16
-               + settings.clientPingRetryInterval;
+               + settings.clientFindPartnerRetryInterval;
 
   if (settings.encryptData == true)
   {
@@ -1145,7 +1145,7 @@ void updateRadioParameters(uint8_t * rxData)
   }
 
   //Update the training values
-  tempSettings.clientPingRetryInterval = params.clientPingRetryInterval;
+  tempSettings.clientFindPartnerRetryInterval = params.clientFindPartnerRetryInterval;
   //The trainingKey is already the same
   tempSettings.trainingTimeout = params.trainingTimeout;
 

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -955,7 +955,7 @@ bool xmitDatagramMpHeartbeat()
   return (transmitDatagram());
 }
 
-//ACK packet sent by server in response the client ping, includes channel number
+//ACK packet sent by server in response the FIND_PARTNER, includes channel number
 //During discovery scanning, it's possible for the client to get an ACK but be on an adjacent channel
 //The channel number ensures that the client gets the next hop correct
 bool xmitDatagramMpAck()
@@ -989,10 +989,10 @@ bool xmitDatagramMpAck()
   return (transmitDatagram());
 }
 
-//Ping packet sent during scanning
-bool xmitDatagramMpPing()
+//FIND_PARTNER packet sent during scanning
+bool xmitDatagramMpFindPartner()
 {
-  radioCallHistory[RADIO_CALL_xmitDatagramMpPing] = millis();
+  radioCallHistory[RADIO_CALL_xmitDatagramMpFindPartner] = millis();
 
   /*
                                     endOfTxData ---.
@@ -3063,7 +3063,7 @@ const I16_TO_STRING radioCallName[] =
   {RADIO_CALL_xmitDatagramMpData, "xmitDatagramMpData"},
   {RADIO_CALL_xmitDatagramMpHeartbeat, "xmitDatagramMpHeartbeat"},
   {RADIO_CALL_xmitDatagramMpAck, "xmitDatagramMpAck"},
-  {RADIO_CALL_xmitDatagramMpPing, "xmitDatagramMpPing"},
+  {RADIO_CALL_xmitDatagramMpFindPartner, "xmitDatagramMpFindPartner"},
   {RADIO_CALL_xmitDatagramTrainingFindPartner, "xmitDatagramTrainingFindPartner"},
   {RADIO_CALL_xmitDatagramTrainingAck, "xmitDatagramTrainingAck"},
   {RADIO_CALL_xmitDatagramTrainRadioParameters, "xmitDatagramTrainRadioParameters"},

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -386,7 +386,7 @@ void processSerialInput()
 
             inCommandMode = true; //Allow AT parsing. Prevent received RF data from being printed.
             forceRadioReset = false; //Don't reset the radio link unless a setting requires it
-            writeOnCommandExit = false; //Don't record settings changes unless user commands it 
+            writeOnCommandExit = false; //Don't record settings changes unless user commands it
 
             tempSettings = settings;
 
@@ -565,14 +565,14 @@ bool vcSerialMessageReceived()
       break;
     }
 
-    //Verify that the destination link is up
+    //Verify that the destination link is connected
     if ((vcDest != VC_BROADCAST)
-      && (virtualCircuitList[vcIndex].vcState == VC_STATE_LINK_DOWN))
+      && (virtualCircuitList[vcIndex].vcState < VC_STATE_CONNECTED))
     {
       if (settings.debugSerial || settings.debugTransmit)
       {
-        systemPrint("Link down ");
-        systemPrint((vcDest == VC_BROADCAST) ? vcDest : vcIndex);
+        systemPrint("Link not connected ");
+        systemPrint(vcIndex);
         systemPrintln(", discarding message!");
         outputSerialData(true);
       }

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -197,6 +197,14 @@ uint8_t readyOutgoingCommandPacket(uint16_t offset)
   if (bytesToSend > maxLength)
     bytesToSend = maxLength;
 
+  if (settings.debugSerial)
+  {
+    systemPrint("Moving ");
+    systemPrint(bytesToSend);
+    systemPrintln(" bytes from commandTXBuffer into outgoingPacket");
+    outputSerialData(true);
+  }
+
   //Determine the number of bytes to send
   length = 0;
   if ((commandTXTail + bytesToSend) > sizeof(commandTXBuffer))

--- a/Firmware/LoRaSerial_Firmware/Serial.ino
+++ b/Firmware/LoRaSerial_Firmware/Serial.ino
@@ -822,7 +822,9 @@ void vcProcessSerialInput()
         }
 
         //Process this command
+        tempSettings = settings;
         checkCommand();
+        settings = tempSettings;
         break;
     }
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1724,7 +1724,9 @@ void updateRadioState()
             //Process the command
             petWDT();
             printerEndpoint = PRINT_TO_RF; //Send prints to RF link
+            tempSettings = settings;
             checkCommand(); //Parse the command buffer
+            settings = tempSettings;
             petWDT();
             printerEndpoint = PRINT_TO_SERIAL;
             length = availableTXCommandBytes();
@@ -2011,7 +2013,9 @@ void updateRadioState()
                 //Process the command
                 petWDT();
                 printerEndpoint = PRINT_TO_RF; //Send prints to RF link
+                tempSettings = settings;
                 checkCommand(); //Parse the command buffer
+                settings = tempSettings;
                 petWDT();
                 printerEndpoint = PRINT_TO_SERIAL;
                 length = availableTXCommandBytes();

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -2482,12 +2482,15 @@ void vcChangeState(int8_t vcIndex, uint8_t state)
   vc = &virtualCircuitList[vcIndex];
   if (state != vc->vcState)
   {
-    //Set the new state
-    vc->vcState = state;
-
     //Display the state change
     if (settings.printLinkUpDown)
     {
+      if ((state == VC_STATE_WAIT_ZERO_ACKS) && (vc->vcState == VC_STATE_CONNECTED))
+      {
+        systemPrint("-=-=- VC ");
+        systemPrint(vcIndex);
+        systemPrintln(" DISCONNECTED -=-=-");
+      }
       if (state == VC_STATE_CONNECTED)
       {
         systemPrint("======= VC ");
@@ -2508,6 +2511,9 @@ void vcChangeState(int8_t vcIndex, uint8_t state)
       }
       outputSerialData(true);
     }
+
+    //Set the new state
+    vc->vcState = state;
 
     //Determine if the VC is connecting
     vcBit = 1 << vcIndex;

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -37,8 +37,9 @@
     ackTimer = datagramTimer;                                                   \
     \
     /*Since ackTimer is off when equal to zero, force it to a non-zero value*/  \
+    /*Subtract one so that the comparisons result in a small number*/           \
     if (!ackTimer)                                                              \
-      ackTimer = 1;                                                             \
+      ackTimer -= 1;                                                            \
   }
 
 #define STOP_ACK_TIMER()      \

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1238,9 +1238,9 @@ void updateRadioState()
     */
 
     //====================
-    //Wait for the PING to complete transmission
+    //Wait for the FIND_PARTNER to complete transmission
     //====================
-    case RADIO_TRAIN_WAIT_TX_PING_DONE:
+    case RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE:
 
       //If dio0ISR has fired, we are done transmitting
       if (transactionComplete == true)
@@ -1248,7 +1248,7 @@ void updateRadioState()
         transactionComplete = false;
 
         //Indicate that the receive is complete
-        triggerEvent(TRIGGER_TRAINING_CLIENT_TX_PING_DONE);
+        triggerEvent(TRIGGER_TRAINING_CLIENT_TX_FIND_PARTNER_DONE);
 
         //Start the receive operation
         returnToReceiving();
@@ -1329,7 +1329,7 @@ void updateRadioState()
         }
         else
         {
-          xmitDatagramTrainingPing(); //Continue retrying as client
+          xmitDatagramTrainingFindPartner(); //Continue retrying as client
         }
       }
       break;
@@ -1377,9 +1377,9 @@ void updateRadioState()
     */
 
     //====================
-    //Wait for a PING frame from a client
+    //Wait for a FIND_PARTNER frame from a client
     //====================
-    case RADIO_TRAIN_WAIT_FOR_PING:
+    case RADIO_TRAIN_WAIT_FOR_FIND_PARTNER:
 
       //If dio0ISR has fired, a packet has arrived
       if (transactionComplete == true)
@@ -1396,7 +1396,7 @@ void updateRadioState()
             triggerEvent(TRIGGER_BAD_PACKET);
             break;
 
-          case DATAGRAM_TRAINING_PING:
+          case DATAGRAM_TRAINING_FIND_PARTNER:
             //Save the client ID
             memcpy(trainingPartnerID, rxData, UNIQUE_ID_BYTES);
 
@@ -1459,7 +1459,7 @@ void updateRadioState()
         returnToReceiving();
 
         //Set the next state
-        changeState(RADIO_TRAIN_WAIT_FOR_PING);
+        changeState(RADIO_TRAIN_WAIT_FOR_FIND_PARTNER);
       }
       break;
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -157,7 +157,7 @@ void updateRadioState()
     //Point-To-Point: Bring up the link
     //
     //A three way handshake is used to get both systems to agree that data can flow in both
-    //directions. This handshake is also used to synchronize the HOP timer.
+    //directions. This handshake is also used to synchronize the HOP timer and zero the ACKs.
     /*
                     System A                 System B
 
@@ -165,39 +165,40 @@ void updateRadioState()
                        |                         |
              Channel 0 |                         | Channel 0
                        V                         V
-           .---> P2P_LINK_DOWN              P2P_LINK_DOWN
-           |           | Tx PING                 |
+           .----> P2P_NO_LINK               P2P_NO_LINK
+           |           | Tx FIND_PARTNER         |
            | Timeout   |                         |
            |           V                         |
-           | P2P_WAIT_TX_PING_DONE               |
+           | P2P_WAIT_TX_FIND_PARTNER_DONE       |
            |           |                         |
-           |           | Tx Complete - - - - - > | Rx PING
+           |           | Tx Complete - - - - - > | Rx FIND_PARTNER
            |           |   Start Rx              |
            |           |   MAX_PACKET_SIZE       |
            |           V                         V
-           `---- P2P_WAIT_ACK_1                  +<----------------------.
-                       |                         | Tx PING ACK1          |
-                       |                         V                       |
-                       |              P2P_WAIT_TX_ACK_1_DONE             |
-                       |                         |                       |
-          Rx PING ACK1 | < - - - - - - - - - - - | Tx Complete           |
-                       |                         |   Start Rx            |
-                       |                         |   MAX_PACKET_SIZE     |
-                       |                         |                       |
-                       V                         V         Timeout       |
-           .---------->+                   P2P_WAIT_ACK_2 -------------->+
-           |   TX PING |                         |                       ^
-           |      ACK2 |                         |                       |
-           |           V                         |                       |
-           | P2P_WAIT_TX_ACK_2_DONE              |                       |
-           |           | Tx Complete - - - - - > | Rx PING ACK2          |
-           | Stop      |   Start HOP timer       |   Start HOP Timer     | Stop
-           | HOP       |   Start Rx              |   Start Rx            | HOP
-           | Timer     |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE     | Timer
-           |           |                         |                       |
-           | Rx        |                         |                       |
-           | PING ACK  V                         V         Rx PING       |
-           `----- P2P_LINK_UP               P2P_LINK_UP -----------------’
+           `---- P2P_WAIT_SYNC_CLOCKS            +<----------------------------.
+                       |                         | Tx SYNC_CLOCKS              |
+                       |                         V                             |
+                       |              P2P_WAIT_TX_SYNC_CLOCKS_DONE             |
+                       |                         |                             |
+        Rx SYNC_CLOCKS | < - - - - - - - - - - - | Tx Complete                 |
+                       |                         |   Start Rx                  |
+                       |                         |   MAX_PACKET_SIZE           |
+                       |                         |                             |
+                       V                         V         Timeout             |
+      .--------------->+                P2P_WAIT_ZERO_ACKS ------------------->+
+      |                |                         |                             ^
+      |                | TX ZERO_ACKS            |                             |
+      |                |                         |                             |
+      |                V                         |                             |
+      |    P2P_WAIT_TX_ZERO_ACKS_DONE            |                             |
+      |                | Tx Complete - - - - - > | Rx ZERO_ACKS                |
+      | Stop           |   Start HOP timer       |   Start HOP Timer           | Stop
+      | HOP            |   Start Rx              |   Start Rx                  | HOP
+      | Timer          |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE           | Timer
+      |                |   Zero ACKs             |   Zero ACKs                 |
+      |       Rx       |                         |                             |
+      |    SYNC_CLOCKS V                         V         Rx FIND_PARTNER     |
+      `---------- P2P_LINK_UP               P2P_LINK_UP -----------------------’
                        |                         |
                        | Rx Data                 | Rx Data
                        |                         |
@@ -205,7 +206,7 @@ void updateRadioState()
 
       Two timers are in use:
         datagramTimer:  Set at end of transmit, measures ACK timeout
-        heartbeatTimer: Set upon entry to P2P_NO_LINK, measures time to send next PING
+        heartbeatTimer: Set upon entry to P2P_NO_LINK, measures time to send next FIND_PARTNER
     */
     //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -110,7 +110,7 @@ void updateRadioState()
 
       //Start the TX timer: time to delay before transmitting the FIND_PARTNER
       setHeartbeatShort(); //Both radios start with short heartbeat period
-      pingRandomTime = random(ackAirTime, ackAirTime * 2); //Fast FIND_PARTNER
+      randomTime = random(ackAirTime, ackAirTime * 2); //Fast FIND_PARTNER
 
       sf6ExpectedSize = headerBytes + CLOCK_MILLIS_BYTES + trailerBytes; //Tell SF6 to receive FIND_PARTNER packet
 
@@ -270,7 +270,7 @@ void updateRadioState()
       }
 
       //Is it time to send the FIND_PARTNER to the remote system
-      else if ((receiveInProcess() == false) && ((millis() - heartbeatTimer) >= pingRandomTime))
+      else if ((receiveInProcess() == false) && ((millis() - heartbeatTimer) >= randomTime))
       {
         //Transmit the FIND_PARTNER
         triggerEvent(TRIGGER_HANDSHAKE_SEND_FIND_PARTNER);
@@ -380,9 +380,9 @@ void updateRadioState()
 
           //Slow down FIND_PARTNERs
           if (ackAirTime < settings.maxDwellTime)
-            pingRandomTime = random(settings.maxDwellTime * 2, settings.maxDwellTime * 4);
+            randomTime = random(settings.maxDwellTime * 2, settings.maxDwellTime * 4);
           else
-            pingRandomTime = random(ackAirTime * 4, ackAirTime * 8);
+            randomTime = random(ackAirTime * 4, ackAirTime * 8);
 
           sf6ExpectedSize = headerBytes + CLOCK_MILLIS_BYTES + trailerBytes; //Tell SF6 to receive FIND_PARTNER packet
           returnToReceiving();
@@ -469,9 +469,9 @@ void updateRadioState()
 
           //Slow down FIND_PARTNERs
           if (ackAirTime < settings.maxDwellTime)
-            pingRandomTime = random(settings.maxDwellTime * 2, settings.maxDwellTime * 4);
+            randomTime = random(settings.maxDwellTime * 2, settings.maxDwellTime * 4);
           else
-            pingRandomTime = random(ackAirTime * 4, ackAirTime * 8);
+            randomTime = random(ackAirTime * 4, ackAirTime * 8);
 
           sf6ExpectedSize = headerBytes + CLOCK_MILLIS_BYTES + trailerBytes; //Tell SF6 to receive FIND_PARTNER packet
           returnToReceiving();

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -2609,7 +2609,7 @@ int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)
   {
     //Verify that an address is present
     vc = &virtualCircuitList[vcIndex];
-    if (!vc->valid)
+    if (!vc->flags.valid)
       continue;
 
     //Compare the unique ID values
@@ -2635,7 +2635,7 @@ int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)
     for (vcIndex = 0; vcIndex < MAX_VC; vcIndex++)
     {
       vc = &virtualCircuitList[vcIndex];
-      if (!virtualCircuitList[vcIndex].valid)
+      if (!virtualCircuitList[vcIndex].flags.valid)
         break;
     }
     if (vcIndex >= MAX_VC)
@@ -2648,7 +2648,7 @@ int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)
   }
 
   //Check for an address conflict
-  if (vc->valid)
+  if (vc->flags.valid)
   {
     systemPrint("ERROR: Unknown ID with pre-assigned conflicting address: ");
     systemPrintln(srcAddr);
@@ -2670,7 +2670,7 @@ int8_t vcIdToAddressByte(int8_t srcAddr, uint8_t * id)
     nvmSaveVcUniqueId(vcIndex);
 
   //Mark this link as up
-  vc->valid = true;
+  vc->flags.valid = true;
   return vcLinkAlive(vcIndex);
 }
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1311,7 +1311,7 @@ void updateRadioState()
       }
 
       //Check for a receive timeout
-      else if ((millis() - datagramTimer) > (settings.clientPingRetryInterval * 1000))
+      else if ((millis() - datagramTimer) > (settings.clientFindPartnerRetryInterval * 1000))
       {
         //If we are training with button, in P2P mode, and user has not set server mode
         //Automatically switch to server

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -1215,24 +1215,24 @@ void updateRadioState()
                 V
                 +<--------------------------------.
                 |                                 |
-                | Send client ping                |
+                | Send FIND_PARTNER               |
                 |                                 |
                 V                                 |
-        RADIO_TRAIN_WAIT_TX_PING_DONE             |
+        RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE     |
                 |                                 |
                 V                                 | Timeout
         RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS -----'
                 |
-                | Update settings
-                | Send client ACK
+                | Save settings
+                | Send ACK
                 |
                 V
-        RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE
+        RADIO_TRAIN_WAIT_TX_ACK_DONE
                 |
                 V
       endTrainingClientServer
                 |
-                | Restore settings
+                | Reboot
                 |
                 V
     */
@@ -1360,21 +1360,18 @@ void updateRadioState()
                         +<--------------------------------.
                         |                                 |
                         V                                 |
-        .------ RADIO_TRAIN_WAIT_FOR_PING                 |
+        .------ RADIO_TRAIN_WAIT_FOR_FIND_PARTNER         |
         |               |                                 |
-        |               | Send client ping                |
+        |               | Send RADIO_PARAMS               |
         |               |                                 |
         |               V                                 |
         |      RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE -----'
         |
         |
         `---------------.
-                        | Stop training command
+                        | ATZ command
                         |
-                        V
-             endTrainingClientServer
-                        |
-                        | Restore settings
+                        | Reboot
                         |
                         V
     */

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -899,7 +899,7 @@ void updateRadioState()
       break;
 
     //====================
-    //Walk through channel table backwards, transmitting a Ping and looking for an ACK1
+    //Walk through channel table backwards, transmitting a FIND_PARTNER and looking for an ACK1
     //====================
     case RADIO_DISCOVER_SCANNING:
       if (transactionComplete)
@@ -1002,18 +1002,18 @@ void updateRadioState()
             }
           }
 
-          //Send ping
-          if (xmitDatagramMpPing() == true)
-            changeState(RADIO_DISCOVER_WAIT_TX_PING_DONE);
+          //Send FIND_PARTNER
+          if (xmitDatagramMpFindPartner() == true)
+            changeState(RADIO_DISCOVER_WAIT_TX_FIND_PARTNER_DONE);
         }
       }
 
       break;
 
     //====================
-    //Wait for the PING to complete transmission
+    //Wait for the FIND_PARTNER to complete transmission
     //====================
-    case RADIO_DISCOVER_WAIT_TX_PING_DONE:
+    case RADIO_DISCOVER_WAIT_TX_FIND_PARTNER_DONE:
       if (transactionComplete)
       {
         transactionComplete = false; //Reset ISR flag
@@ -1099,7 +1099,7 @@ void updateRadioState()
               //Ack their FIND_PARTNER with sync data
               if (xmitDatagramMpAck() == true)
               {
-                triggerEvent(TRIGGER_MP_SEND_ACK_FOR_PING);
+                triggerEvent(TRIGGER_MP_SEND_ACK_FOR_FIND_PARTNER);
                 changeState(RADIO_MP_WAIT_TX_ACK_DONE);
               }
             }

--- a/Firmware/LoRaSerial_Firmware/System.ino
+++ b/Firmware/LoRaSerial_Firmware/System.ino
@@ -681,22 +681,7 @@ void radioLeds()
   }
 
   //Update the link LED
-  switch (radioState)
-  {
-    //Turn off the LED
-    default:
-      digitalWrite(RADIO_USE_LINK_LED, LED_OFF);
-      break;
-
-    //Turn on the LED
-    case RADIO_P2P_LINK_UP:
-    case RADIO_P2P_LINK_UP_WAIT_ACK_DONE:
-    case RADIO_P2P_LINK_UP_WAIT_TX_DONE:
-    case RADIO_P2P_LINK_UP_WAIT_ACK:
-    case RADIO_P2P_LINK_UP_HB_ACK_REXMT:
-      digitalWrite(RADIO_USE_LINK_LED, LED_ON);
-      break;
-  }
+  digitalWrite(RADIO_USE_LINK_LED, isLinked() ? LED_ON : LED_OFF);
 
   //Update the RSSI LED
   if (currentMillis != previousMillis)

--- a/Firmware/LoRaSerial_Firmware/Train.ino
+++ b/Firmware/LoRaSerial_Firmware/Train.ino
@@ -62,10 +62,10 @@ void beginTrainingClient()
   //Common initialization
   commonTrainingInitialization();
 
-  //Transmit client ping to the training server
-  if (xmitDatagramTrainingPing() == true)
+  //Transmit FIND_PARTNER to the training server
+  if (xmitDatagramTrainingFindPartner() == true)
     //Set the next state
-    changeState(RADIO_TRAIN_WAIT_TX_PING_DONE);
+    changeState(RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE);
   else
     changeState(RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS);
   trainingTimer = millis();
@@ -104,7 +104,7 @@ void beginTrainingServer()
   returnToReceiving();
 
   //Set the next state
-  changeState(RADIO_TRAIN_WAIT_FOR_PING);
+  changeState(RADIO_TRAIN_WAIT_FOR_FIND_PARTNER);
 }
 
 //Perform the common training initialization

--- a/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
+++ b/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
@@ -34,6 +34,7 @@
 #define PC_LINK_STATUS      (PC_COMMAND + 1)    //Asynchronous link status output
 #define PC_DATA_ACK         (PC_LINK_STATUS + 1)//Indicate data delivery success
 #define PC_DATA_NACK        (PC_DATA_ACK + 1)   //Indicate data delivery failure
+#define PC_SERIAL_RECONNECT (PC_DATA_NACK + 1)  //Disconnect/reconnect the serial port over LoRaSerial CPU reset
 
 //Address space 1 and 2 are reserved for the host PC interface to support remote
 //command processing.  The radio removes these bits and converts them to the

--- a/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
+++ b/Firmware/LoRaSerial_Firmware/Virtual_Circuit_Protocol.h
@@ -139,13 +139,12 @@ typedef struct _VC_STATE_MESSAGE
 
 typedef enum
 {
-  VC_STATE_LINK_DOWN = 0, //0: HEARTBEATs not received
-  VC_STATE_LINK_ALIVE,    //1: Receiving HEARTBEATs, waiting for PING
-  VC_STATE_SEND_PING,     //2: ATC command received, sending PING
-  VC_STATE_WAIT_FOR_ACK1 ,//3: PING sent, waiting for ACK1
-  VC_STATE_WAIT_FOR_ACK2 ,//4: ACK1 sent, waiting for ACK2
-  VC_STATE_CONNECTED,     //5: ACK2 received, ACKs cleared, ready to send data
-  VC_STATE_NEW_CLIENT,    //6: A server received a PING from a previously unknown client
+  VC_STATE_LINK_DOWN = 0,     //0: HEARTBEATs not received
+  VC_STATE_LINK_ALIVE,        //1: Receiving HEARTBEATs, waiting for UNKNOWN_ACKS
+  VC_STATE_SEND_UNKNOWN_ACKS, //2: ATC command received, sending UNKNOWN_ACKS
+  VC_STATE_WAIT_SYNC_ACKS,    //3: UNKNOWN_ACKS sent, waiting for SYNC_ACKS
+  VC_STATE_WAIT_ZERO_ACKS,    //4: SYNC_ACKS sent, waiting for ZERO_ACKS
+  VC_STATE_CONNECTED,         //5: ZERO_ACKS received, ACKs cleared, ready to send data
 
   //Insert new states before this line
   VC_STATE_MAX
@@ -173,8 +172,8 @@ typedef struct _VC_DATA_ACK_NACK_MESSAGE
 const char * const vcStateNames[] =
 { //   0            1
   "LINK-DOWN", "LINK-ALIVE",
-  //   2            3            4            5            6
-  "SEND-PING", "WAIT-ACK1", "WAIT-ACK2", "CONNECTED", "NEW-CLIENT",
+  //     2             3            4            5
+  "UNKNOWN-ACKS", "SYNC-ACKS", "ZERO-ACKS", "CONNECTED",
 };
 #endif  //ADD_VC_STATE_NAMES_TABLE
 

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -25,12 +25,12 @@ typedef enum
   RADIO_MP_WAIT_TX_DONE,
 
   //Training client states
-  RADIO_TRAIN_WAIT_TX_PING_DONE,
+  RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE,
   RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS,
   RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,
 
   //Training server states
-  RADIO_TRAIN_WAIT_FOR_PING,
+  RADIO_TRAIN_WAIT_FOR_FIND_PARTNER,
   RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,
 
   //Virtual-Circuit states
@@ -85,14 +85,14 @@ const RADIO_STATE_ENTRY radioStateTable[] =
 
   //Training client states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //15
-  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //16
-  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //17
+  {RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE,0, "TRAIN_WAIT_TX_FIND_PARTNER_DONE","Train: Wait TX training FIND_PARTNER done"}, //15
+  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},          //16
+  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},         //17
 
   //Training server states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //18
-  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //19
+  {RADIO_TRAIN_WAIT_FOR_FIND_PARTNER,    1, "TRAIN_WAIT_FOR_FIND_PARTNER",    "Train: Wait for training FIND_PARTNER"}, //18
+  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},        //19
 
   //Virtual circuit states
   //    State                           RX      Name                              Description
@@ -122,7 +122,7 @@ typedef enum
   DATAGRAM_DATAGRAM,                // 8
 
   //Multi-Point training exchange
-  DATAGRAM_TRAINING_PING,           // 9
+  DATAGRAM_TRAINING_FIND_PARTNER,   // 9
   DATAGRAM_TRAINING_PARAMS,         //10
   DATAGRAM_TRAINING_ACK,            //11
 
@@ -152,8 +152,8 @@ const char * const radioDatagramType[] =
   "DATA", "DATA-ACK", "HEARTBEAT", "RMT-CMD", "RMT_RESP",
   //  8
   "DATAGRAM",
-  //     9                 10               11
-  "TRAINING_PING", "TRAINING_PARAMS", "TRAINING_ACK",
+  //         9                    10                11
+  "TRAINING_FIND_PARTNER", "TRAINING_PARAMS", "TRAINING_ACK",
   //    12
   "VC_HEARTBEAT",
   //      13               14              15
@@ -286,7 +286,7 @@ enum
   TRIGGER_TRAINING_CONTROL_PACKET,
   TRIGGER_TRAINING_DATA_PACKET,
   TRIGGER_TRAINING_NO_ACK,
-  TRIGGER_TRAINING_CLIENT_TX_PING_DONE,
+  TRIGGER_TRAINING_CLIENT_TX_FIND_PARTNER_DONE,
   TRIGGER_TRAINING_CLIENT_RX_PARAMS,
   TRIGGER_TRAINING_CLIENT_TX_ACK_DONE,
   TRIGGER_TRAINING_SERVER_RX,
@@ -497,8 +497,6 @@ typedef enum
   RADIO_CALL_setRadioFrequency,
   RADIO_CALL_returnToReceiving,
   RADIO_CALL_calcAirTime,
-  RADIO_CALL_xmitDatagramP2PTrainingPing,
-  RADIO_CALL_xmitDatagramP2pTrainingParams,
   RADIO_CALL_xmitDatagramP2PFindPartner,
   RADIO_CALL_xmitDatagramP2PAck1,
   RADIO_CALL_xmitDatagramP2PAck2,
@@ -511,7 +509,7 @@ typedef enum
   RADIO_CALL_xmitDatagramMpHeartbeat,
   RADIO_CALL_xmitDatagramMpAck,
   RADIO_CALL_xmitDatagramMpPing,
-  RADIO_CALL_xmitDatagramTrainingPing,
+  RADIO_CALL_xmitDatagramTrainingFindPartner,
   RADIO_CALL_xmitDatagramTrainingAck,
   RADIO_CALL_xmitDatagramTrainRadioParameters,
   RADIO_CALL_xmitVcDatagram,

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -416,7 +416,7 @@ typedef struct struct_settings {
   bool enableCRC16 = false; //Append CRC-16 to packet, check CRC-16 upon receive
   bool displayRealMillis = false; //true = Display the millis value without offset, false = use offset
   bool server = false; //Default to being a client, enable server for multipoint, VC and training
-  uint8_t clientPingRetryInterval = 3; //Number of seconds before retransmiting the client PING
+  uint8_t clientFindPartnerRetryInterval = 3; //Number of seconds before retransmiting the client FIND_PARTNER
   bool copyDebug = false; //Copy the debug parameters to the training client
   bool copySerial = false; //Copy the serial parameters to the training client
   bool copyTriggers = false; //Copy the trigger parameters to the training client

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -17,7 +17,7 @@ typedef enum
   //Server-client discovery
   RADIO_DISCOVER_BEGIN,
   RADIO_DISCOVER_SCANNING,
-  RADIO_DISCOVER_WAIT_TX_PING_DONE,
+  RADIO_DISCOVER_WAIT_TX_FIND_PARTNER_DONE,
 
   //Multi-Point: Datagrams
   RADIO_MP_WAIT_TX_ACK_DONE,
@@ -73,9 +73,9 @@ const RADIO_STATE_ENTRY radioStateTable[] =
 
   //Server-client discovery
   //    State                           RX      Name                              Description
-  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        // 9
-  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //10
-  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //11
+  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},                  // 9
+  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},                //10
+  {RADIO_DISCOVER_WAIT_TX_FIND_PARTNER_DONE,0,"DISCOVER_WAIT_TX_FIND_PARTNER_DONE","Disc: Wait for FIND_PARTNER to xmit"},  //11
 
   //Multi-Point data exchange
   //    State                           RX      Name                              Description
@@ -260,7 +260,7 @@ enum
   TRIGGER_MP_SCAN,
   TRIGGER_MP_DATA_PACKET,
   TRIGGER_MP_PACKET_RECEIVED,
-  TRIGGER_MP_SEND_ACK_FOR_PING,
+  TRIGGER_MP_SEND_ACK_FOR_FIND_PARTNER,
   TRIGGER_TRANSMIT_CANCELED,
   TRIGGER_HANDSHAKE_ACK1_TIMEOUT,
   TRIGGER_HANDSHAKE_SEND_FIND_PARTNER,
@@ -385,7 +385,7 @@ typedef struct struct_settings {
   uint16_t serialTimeoutBeforeSendingFrame_ms = 50; //Send partial buffer if time expires
   bool debug = false; //Print basic events: ie, radio state changes
   bool echo = false; //Print locally inputted serial
-  uint16_t heartbeatTimeout = 5000; //ms before sending ping to see if link is active
+  uint16_t heartbeatTimeout = 5000; //ms before sending HEARTBEAT to see if link is active
   bool flowControl = false; //Enable the use of CTS/RTS flow control signals
   bool autoTuneFrequency = false; //Based on the last packets frequency error, adjust our next transaction frequency
   bool printPacketQuality = false; //Print RSSI, SNR, and freqError for received packets
@@ -508,7 +508,7 @@ typedef enum
   RADIO_CALL_xmitDatagramMpData,
   RADIO_CALL_xmitDatagramMpHeartbeat,
   RADIO_CALL_xmitDatagramMpAck,
-  RADIO_CALL_xmitDatagramMpPing,
+  RADIO_CALL_xmitDatagramMpFindPartner,
   RADIO_CALL_xmitDatagramTrainingFindPartner,
   RADIO_CALL_xmitDatagramTrainingAck,
   RADIO_CALL_xmitDatagramTrainRadioParameters,

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -160,6 +160,11 @@ const char * const radioDatagramType[] =
   "VC_UNKNOWN_ACKS", "VC_SYNC_ACKS", "VC_ZERO_ACKS",
 };
 
+typedef struct _VC_FLAGS
+{
+  bool valid : 1;           //Unique ID is valid
+} VC_FLAGS;
+
 typedef struct _VIRTUAL_CIRCUIT
 {
   uint8_t uniqueId[UNIQUE_ID_BYTES];
@@ -176,7 +181,8 @@ typedef struct _VIRTUAL_CIRCUIT
   uint32_t linkFailures;      //myVc <-> VC, Total number of link failures
 
   //Link management
-  bool valid;                 //Unique ID is valid
+
+  VC_FLAGS flags;
   uint8_t vcState;            //State of VC
 
   /* ACK number management

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -12,10 +12,7 @@ typedef enum
 
   //Point-to-Point: Link up, data exchange
   RADIO_P2P_LINK_UP,
-  RADIO_P2P_LINK_UP_WAIT_ACK_DONE,
   RADIO_P2P_LINK_UP_WAIT_TX_DONE,
-  RADIO_P2P_LINK_UP_WAIT_ACK,
-  RADIO_P2P_LINK_UP_HB_ACK_REXMT,
 
   //Server-client discovery
   RADIO_DISCOVER_BEGIN,
@@ -71,38 +68,35 @@ const RADIO_STATE_ENTRY radioStateTable[] =
   //Point-to-Point, link up, data exchange
   //    State                           RX      Name                              Description
   {RADIO_P2P_LINK_UP,                    1, "P2P_LINK_UP",                    "P2P: Receiving Standby"},          //10
-  {RADIO_P2P_LINK_UP_WAIT_ACK_DONE,      0, "P2P_LINK_UP_WAIT_ACK_DONE",      "P2P: Waiting ACK TX Done"},        //11
-  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            //12
-  {RADIO_P2P_LINK_UP_WAIT_ACK,           1, "P2P_LINK_UP_WAIT_ACK",           "P2P: Waiting for ACK"},            //13
-  {RADIO_P2P_LINK_UP_HB_ACK_REXMT,       0, "P2P_LINK_UP_HB_ACK_REXMT",       "P2P: Heartbeat ACK ReXmt"},        //14
+  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            //11
 
   //Server-client discovery
   //    State                           RX      Name                              Description
-  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        //15
-  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //16
-  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //17
+  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        //12
+  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //13
+  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //14
 
   //Multi-Point data exchange
   //    State                           RX      Name                              Description
-  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //18
-  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //19
-  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //20
+  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //15
+  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //16
+  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //17
 
   //Training client states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //21
-  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //22
-  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //23
+  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //18
+  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //19
+  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //20
 
   //Training server states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //24
-  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //25
+  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //21
+  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //22
 
   //Virtual circuit states
   //    State                           RX      Name                              Description
-  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //27
-  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //28
+  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //23
+  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //24
 };
 
 //Possible types of packets received

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -163,6 +163,7 @@ const char * const radioDatagramType[] =
 typedef struct _VC_FLAGS
 {
   bool valid : 1;           //Unique ID is valid
+  bool wasConnected : 1;    //The VC was previously connected
 } VC_FLAGS;
 
 typedef struct _VIRTUAL_CIRCUIT

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -4,7 +4,7 @@ typedef enum
 
   //Point-To-Point: Bring up the link
   RADIO_P2P_LINK_DOWN,
-  RADIO_P2P_WAIT_TX_PING_DONE,
+  RADIO_P2P_WAIT_TX_FIND_PARTNER_DONE,
   RADIO_P2P_WAIT_ACK_1,
   RADIO_P2P_WAIT_TX_ACK_1_DONE,
   RADIO_P2P_WAIT_ACK_2,
@@ -59,8 +59,8 @@ const RADIO_STATE_ENTRY radioStateTable[] =
 
   //Point-to-Point link handshake
   //    State                           RX      Name                              Description
-  {RADIO_P2P_LINK_DOWN,                  1, "P2P_LINK_DOWN",                  "P2P: [No Link] Waiting for Ping"}, // 1
-  {RADIO_P2P_WAIT_TX_PING_DONE,          0, "P2P_WAIT_TX_PING_DONE",          "P2P: [No Link] Wait Ping TX Done"},// 2
+  {RADIO_P2P_LINK_DOWN,                  1, "P2P_LINK_DOWN",                  "P2P: [No Link] Waiting for FIND_PARTNER"}, // 1
+  {RADIO_P2P_WAIT_TX_FIND_PARTNER_DONE,  0, "P2P_WAIT_TX_FIND_PARTNER_DONE",  "P2P: [No Link] Wait FIND_PARTNER TX Done"},// 2
   {RADIO_P2P_WAIT_ACK_1,                 1, "P2P_WAIT_ACK_1",                 "P2P: [No Link] Waiting for ACK1"}, // 3
   {RADIO_P2P_WAIT_TX_ACK_1_DONE,         0, "P2P_WAIT_TX_ACK_1_DONE",         "P2P: [No Link] Wait ACK1 TX Done"},// 4
   {RADIO_P2P_WAIT_ACK_2,                 1, "P2P_WAIT_ACK_2",                 "P2P: [No Link] Waiting for ACK2"}, // 5
@@ -107,7 +107,7 @@ typedef enum
   //Sync frequencies, HEARTBEAT timing and zero ACKs
   //P2P: Between the two LoRaSerial radios
   //VC:  Between the server radio and a client radio
-  DATAGRAM_PING = 0,                // 0
+  DATAGRAM_FIND_PARTNER = 0,        // 0
   DATAGRAM_ACK_1,                   // 1
   DATAGRAM_ACK_2,                   // 2
 
@@ -146,8 +146,8 @@ typedef enum
 } PacketType;
 
 const char * const radioDatagramType[] =
-{ // 0       1        2
-  "PING", "ACK-1", "ACK-2",
+{ //    0            1        2
+  "FIND_PARTNER", "ACK-1", "ACK-2",
   // 3        4           5            6           7
   "DATA", "DATA-ACK", "HEARTBEAT", "RMT-CMD", "RMT_RESP",
   //  8
@@ -263,8 +263,8 @@ enum
   TRIGGER_MP_SEND_ACK_FOR_PING,
   TRIGGER_TRANSMIT_CANCELED,
   TRIGGER_HANDSHAKE_ACK1_TIMEOUT,
-  TRIGGER_HANDSHAKE_SEND_PING,
-  TRIGGER_HANDSHAKE_SEND_PING_COMPLETE,
+  TRIGGER_HANDSHAKE_SEND_FIND_PARTNER,
+  TRIGGER_HANDSHAKE_SEND_FIND_PARTNER_COMPLETE,
   TRIGGER_HANDSHAKE_SEND_ACK1_COMPLETE,
   TRIGGER_SEND_ACK1,
   TRIGGER_SEND_ACK2,
@@ -499,7 +499,7 @@ typedef enum
   RADIO_CALL_calcAirTime,
   RADIO_CALL_xmitDatagramP2PTrainingPing,
   RADIO_CALL_xmitDatagramP2pTrainingParams,
-  RADIO_CALL_xmitDatagramP2PPing,
+  RADIO_CALL_xmitDatagramP2PFindPartner,
   RADIO_CALL_xmitDatagramP2PAck1,
   RADIO_CALL_xmitDatagramP2PAck2,
   RADIO_CALL_xmitDatagramP2PCommand,

--- a/Firmware/LoRaSerial_Firmware/settings.h
+++ b/Firmware/LoRaSerial_Firmware/settings.h
@@ -34,6 +34,7 @@ typedef enum
   RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,
 
   //Virtual-Circuit states
+  RADIO_VC_WAIT_SERVER,
   RADIO_VC_WAIT_TX_DONE,
   RADIO_VC_WAIT_RECEIVE,
 
@@ -58,51 +59,54 @@ const RADIO_STATE_ENTRY radioStateTable[] =
 
   //Point-to-Point link handshake
   //    State                           RX      Name                              Description
-  {RADIO_P2P_LINK_DOWN,                  1, "P2P_LINK_DOWN",                  "P2P: [No Link] Waiting for Ping"}, // 4
-  {RADIO_P2P_WAIT_TX_PING_DONE,          0, "P2P_WAIT_TX_PING_DONE",          "P2P: [No Link] Wait Ping TX Done"},// 5
-  {RADIO_P2P_WAIT_ACK_1,                 1, "P2P_WAIT_ACK_1",                 "P2P: [No Link] Waiting for ACK1"}, // 6
-  {RADIO_P2P_WAIT_TX_ACK_1_DONE,         0, "P2P_WAIT_TX_ACK_1_DONE",         "P2P: [No Link] Wait ACK1 TX Done"},// 7
-  {RADIO_P2P_WAIT_ACK_2,                 1, "P2P_WAIT_ACK_2",                 "P2P: [No Link] Waiting for ACK2"}, // 8
-  {RADIO_P2P_WAIT_TX_ACK_2_DONE,         0, "P2P_WAIT_TX_ACK_2_DONE",         "P2P: [No Link] Wait ACK2 TX Done"},// 9
+  {RADIO_P2P_LINK_DOWN,                  1, "P2P_LINK_DOWN",                  "P2P: [No Link] Waiting for Ping"}, // 1
+  {RADIO_P2P_WAIT_TX_PING_DONE,          0, "P2P_WAIT_TX_PING_DONE",          "P2P: [No Link] Wait Ping TX Done"},// 2
+  {RADIO_P2P_WAIT_ACK_1,                 1, "P2P_WAIT_ACK_1",                 "P2P: [No Link] Waiting for ACK1"}, // 3
+  {RADIO_P2P_WAIT_TX_ACK_1_DONE,         0, "P2P_WAIT_TX_ACK_1_DONE",         "P2P: [No Link] Wait ACK1 TX Done"},// 4
+  {RADIO_P2P_WAIT_ACK_2,                 1, "P2P_WAIT_ACK_2",                 "P2P: [No Link] Waiting for ACK2"}, // 5
+  {RADIO_P2P_WAIT_TX_ACK_2_DONE,         0, "P2P_WAIT_TX_ACK_2_DONE",         "P2P: [No Link] Wait ACK2 TX Done"},// 6
 
   //Point-to-Point, link up, data exchange
   //    State                           RX      Name                              Description
-  {RADIO_P2P_LINK_UP,                    1, "P2P_LINK_UP",                    "P2P: Receiving Standby"},          //10
-  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            //11
+  {RADIO_P2P_LINK_UP,                    1, "P2P_LINK_UP",                    "P2P: Receiving Standby"},          // 7
+  {RADIO_P2P_LINK_UP_WAIT_TX_DONE,       0, "P2P_LINK_UP_WAIT_TX_DONE",       "P2P: Waiting TX done"},            // 8
 
   //Server-client discovery
   //    State                           RX      Name                              Description
-  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        //12
-  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //13
-  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //14
+  {RADIO_DISCOVER_BEGIN,                 0, "DISCOVER_BEGIN",                 "Disc: Setup for scanning"},        // 9
+  {RADIO_DISCOVER_SCANNING,              0, "DISCOVER_SCANNING",              "Disc: Scanning for servers"},      //10
+  {RADIO_DISCOVER_WAIT_TX_PING_DONE,     0, "DISCOVER_WAIT_TX_PING_DONE",     "Disc: Wait for ping to xmit"},     //11
 
   //Multi-Point data exchange
   //    State                           RX      Name                              Description
-  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //15
-  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //16
-  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //17
+  {RADIO_MP_WAIT_TX_ACK_DONE,            0, "MP_WAIT_TX_ACK_DONE",            "MP: Wait for ACK to xmit"},        //12
+  {RADIO_MP_STANDBY,                     1, "MP_STANDBY",                     "MP: Wait for TX or RX"},           //13
+  {RADIO_MP_WAIT_TX_DONE,                0, "MP_WAIT_TX_DONE",                "MP: Waiting for TX done"},         //14
 
   //Training client states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //18
-  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //19
-  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //20
+  {RADIO_TRAIN_WAIT_TX_PING_DONE,        0, "TRAIN_WAIT_TX_PING_DONE",        "Train: Wait TX training PING done"},  //15
+  {RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS, 1, "TRAIN_WAIT_RX_RADIO_PARAMETERS", "Train: Wait for radio parameters"},   //16
+  {RADIO_TRAIN_WAIT_TX_PARAM_ACK_DONE,   0, "TRAIN_WAIT_TX_PARAM_ACK_DONE",   "Train: Wait for TX param ACK done"},  //17
 
   //Training server states
   //    State                           RX      Name                              Description
-  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //21
-  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //22
+  {RADIO_TRAIN_WAIT_FOR_PING,            1, "TRAIN_WAIT_FOR_PING",            "Train: Wait for training PING"},      //18
+  {RADIO_TRAIN_WAIT_TX_RADIO_PARAMS_DONE,0, "TRAIN_WAIT_TX_RADIO_PARAMS_DONE","Train: Wait for TX params done"},     //19
 
   //Virtual circuit states
   //    State                           RX      Name                              Description
-  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //23
-  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //24
+  {RADIO_VC_WAIT_SERVER,                 1, "VC_WAIT_SERVER",                 "VC: Wait for the server"},         //20
+  {RADIO_VC_WAIT_TX_DONE,                0, "VC_WAIT_TX_DONE",                "VC: Wait for TX done"},            //21
+  {RADIO_VC_WAIT_RECEIVE,                1, "VC_WAIT_RECEIVE",                "VC: Wait for receive"},            //22
 };
 
 //Possible types of packets received
 typedef enum
 {
-  //Link establishment handshake
+  //Sync frequencies, HEARTBEAT timing and zero ACKs
+  //P2P: Between the two LoRaSerial radios
+  //VC:  Between the server radio and a client radio
   DATAGRAM_PING = 0,                // 0
   DATAGRAM_ACK_1,                   // 1
   DATAGRAM_ACK_2,                   // 2
@@ -124,6 +128,9 @@ typedef enum
 
   //Virtual-Circuit (VC) exchange
   DATAGRAM_VC_HEARTBEAT,            //12
+  DATAGRAM_VC_UNKNOWN_ACKS,         //13 Synchronize ACKs client VC to client VC
+  DATAGRAM_VC_SYNC_ACKS,            //14
+  DATAGRAM_VC_ZERO_ACKS,            //15
 
   //Add new datagram types before this line
   MAX_DATAGRAM_TYPE,
@@ -149,6 +156,8 @@ const char * const radioDatagramType[] =
   "TRAINING_PING", "TRAINING_PARAMS", "TRAINING_ACK",
   //    12
   "VC_HEARTBEAT",
+  //      13               14              15
+  "VC_UNKNOWN_ACKS", "VC_SYNC_ACKS", "VC_ZERO_ACKS",
 };
 
 typedef struct _VIRTUAL_CIRCUIT
@@ -156,7 +165,7 @@ typedef struct _VIRTUAL_CIRCUIT
   uint8_t uniqueId[UNIQUE_ID_BYTES];
   unsigned long firstHeartbeatMillis; //Time VC link came up
   unsigned long lastTrafficMillis; //Last time a frame was received
-  unsigned long lastPingMillis; //Last time a ping was sent or ACK received
+  unsigned long timerMillis; //Last time the timer was started, after handshake or ACK
 
   //Link quality metrics
   uint32_t framesSent;        //myVc --> VC, Total number of frames sent
@@ -501,9 +510,9 @@ typedef enum
   RADIO_CALL_xmitVcDatagram,
   RADIO_CALL_xmitVcHeartbeat,
   RADIO_CALL_xmitVcAckFrame,
-  RADIO_CALL_xmitVcPing,
-  RADIO_CALL_xmitVcAck1,
-  RADIO_CALL_xmitVcAck2,
+  RADIO_CALL_xmitVcUnknownAcks,
+  RADIO_CALL_xmitVcSyncAcks,
+  RADIO_CALL_xmitVcZeroAcks,
   RADIO_CALL_rcvDatagram,
   RADIO_CALL_transmitDatagram,
   RADIO_CALL_retransmitDatagram,

--- a/Firmware/Tools/VcServerTest.c
+++ b/Firmware/Tools/VcServerTest.c
@@ -14,7 +14,7 @@
 
 #define DEBUG_LOCAL_COMMANDS      0
 #define DEBUG_PC_TO_RADIO         0
-#define DEBUG_RADIO_TO_PC         0
+#define DEBUG_RADIO_TO_PC         1
 #define DISPLAY_DATA_ACK          1
 #define DISPLAY_DATA_NACK         1
 #define DISPLAY_VC_STATE          0
@@ -305,19 +305,19 @@ void radioToPcLinkStatus(VC_SERIAL_MESSAGE_HEADER * header, uint8_t length)
       printf("-=--=--=- VC %d ALIVE =--=--=-\n", srcVc);
     break;
 
-  case VC_STATE_SEND_PING:
+  case VC_STATE_SEND_UNKNOWN_ACKS:
     if (DISPLAY_VC_STATE)
-      printf("-=--=-- VC %d ALIVE P1 --=--=-\n", srcVc);
+      printf("-=--=-- VC %d ALIVE UA --=--=-\n", srcVc);
     break;
 
-  case VC_STATE_WAIT_FOR_ACK1:
+  case VC_STATE_WAIT_SYNC_ACKS:
     if (DISPLAY_VC_STATE)
-      printf("-=--=-- VC %d ALIVE WA1 -=--=-\n", srcVc);
+      printf("-=--=-- VC %d ALIVE SA --=--=-\n", srcVc);
     break;
 
-  case VC_STATE_WAIT_FOR_ACK2:
+  case VC_STATE_WAIT_ZERO_ACKS:
     if (DISPLAY_VC_STATE)
-      printf("-=--=-- VC %d ALIVE WA2 -=--=-\n", srcVc);
+      printf("-=--=-- VC %d ALIVE ZA --=--=-\n", srcVc);
     break;
 
   case VC_STATE_CONNECTED:
@@ -356,7 +356,7 @@ int radioToHost()
   static uint8_t * dataEnd = outputBuffer;
   int8_t destAddr;
   static VC_SERIAL_MESSAGE_HEADER * header = (VC_SERIAL_MESSAGE_HEADER *)outputBuffer;
-  uint8_t length;
+  int length;
   int maxfds;
   int status;
   int8_t srcAddr;
@@ -413,7 +413,7 @@ int radioToHost()
     data = dataStart;
 
     //Determine if the VC header is in the buffer
-    if (length < VC_SERIAL_HEADER_BYTES)
+    if (length < (int)VC_SERIAL_HEADER_BYTES)
       //Need more data
       break;
 

--- a/Firmware/Tools/VcServerTest.c
+++ b/Firmware/Tools/VcServerTest.c
@@ -317,7 +317,11 @@ void radioToPcLinkStatus(VC_SERIAL_MESSAGE_HEADER * header, uint8_t length)
 
   case VC_STATE_WAIT_ZERO_ACKS:
     if (DISPLAY_VC_STATE)
+    {
+      if (previousState == VC_STATE_CONNECTED)
+        printf("-=-=- VC %d DISCONNECTED -=-=-", srcVc);
       printf("-=--=-- VC %d ALIVE ZA --=--=-\n", srcVc);
+    }
     break;
 
   case VC_STATE_CONNECTED:


### PR DESCRIPTION
Fix bug when ackTimer is zero and a comparison is done immediately.

    millis() = 0
    ackTimer = 1
           -  ___
              -1 = 0xFFFFFFFF
If the resulting value is treated as an unsigned number it is larger than all of the timeout values.
Fix:

    millis() = 0
    ackTimer = -1 (0xFFFFFFFF)
            - ____
               1

This result value reduces the expected timeout value by one millisecond which is significantly less than all of the timeouts.
