### PR TITLE
Define a single source for channelTimer corrections

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Begin.ino
+++ b/Firmware/LoRaSerial_Firmware/Begin.ino
@@ -100,9 +100,9 @@ void channelTimerHandler()
   timerStart = millis(); //Record when this ISR happened. Used for calculating clock sync.
 
   //If the last timer was used to sync clocks, restore full timer interval
-  if (partialTimer == true)
+  if (reloadChannelTimer == true)
   {
-    partialTimer = false;
+    reloadChannelTimer = false;
     channelTimer.setInterval_MS(settings.maxDwellTime, channelTimerHandler);
   }
 

--- a/Firmware/LoRaSerial_Firmware/Begin.ino
+++ b/Firmware/LoRaSerial_Firmware/Begin.ino
@@ -97,7 +97,7 @@ void beginChannelTimer()
 //ISR that fires when channel timer expires
 void channelTimerHandler()
 {
-  timerStart = millis(); //Record when this ISR happened. Used for calculating clock sync.
+  channelTimerStart = millis(); //Record when this ISR happened. Used for calculating clock sync.
 
   //If the last timer was used to sync clocks, restore full timer interval
   if (reloadChannelTimer == true)

--- a/Firmware/LoRaSerial_Firmware/Begin.ino
+++ b/Firmware/LoRaSerial_Firmware/Begin.ino
@@ -91,7 +91,7 @@ void beginChannelTimer()
   if (channelTimer.attachInterruptInterval_MS(settings.maxDwellTime, channelTimerHandler) == false)
     Serial.println("Error starting ChannelTimer!");
 
-  stopChannelTimer(); //Start timer only after link is up
+  stopChannelTimer(); //Start timer in state machine - beginChannelTimer
 }
 
 //ISR that fires when channel timer expires

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -161,7 +161,7 @@ bool trainViaButton = false; //Allows auto-creation of server if client times ou
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 #include "SAMDTimerInterrupt.h" //http://librarymanager/All#SAMD_TimerInterrupt v1.9.0 (currently) by Koi Hang
 SAMDTimer channelTimer(TIMER_TCC); //Available: TC3, TC4, TC5, TCC, TCC1 or TCC2
-unsigned long timerStart = 0; //Tracks how long our timer has been running since last hop
+unsigned long channelTimerStart = 0; //Tracks how long our timer has been running since last hop
 bool reloadChannelTimer = false; //When set channel timer interval needs to be reloaded with settings.maxDwellTime
 
 uint16_t petTimeout = 0; //A reduced amount of time before WDT triggers. Helps reduce amount of time spent petting.

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -519,7 +519,7 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 /*
-          Server                                Client
+                 Clock Sync Transmitter         Clock Sync Receiver
 
                   HEARTBEAT send needed
           call xmitDatagramP2PHeartbeat
@@ -578,6 +578,8 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 
 //Clock synchronization
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+bool clockSyncReceiver; //Receives and processes the clock synchronization
 
 //RX and TX time measurements
 uint32_t rxTimeUsec;

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -162,7 +162,7 @@ bool trainViaButton = false; //Allows auto-creation of server if client times ou
 #include "SAMDTimerInterrupt.h" //http://librarymanager/All#SAMD_TimerInterrupt v1.9.0 (currently) by Koi Hang
 SAMDTimer channelTimer(TIMER_TCC); //Available: TC3, TC4, TC5, TCC, TCC1 or TCC2
 unsigned long timerStart = 0; //Tracks how long our timer has been running since last hop
-bool partialTimer = false; //After an ACK we reset and run a partial timer to sync units
+bool reloadChannelTimer = false; //When set channel timer interval needs to be reloaded with settings.maxDwellTime
 
 uint16_t petTimeout = 0; //A reduced amount of time before WDT triggers. Helps reduce amount of time spent petting.
 unsigned long lastPet = 0; //Remebers time of last WDT pet.

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -2938,6 +2938,7 @@ void syncChannelTimer()
   currentMillis = millis();
   radioCallHistory[RADIO_CALL_syncChannelTimer] = currentMillis;
 
+  if (!clockSyncReceiver) return; //syncChannelTimer
   if (settings.frequencyHop == false) return;
 
   //msToNextHopRemote is in the range of 0 - settings.maxDwellTime

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -2495,7 +2495,7 @@ bool transmitDatagram()
     //Hake sure that the transmitted msToNextHop is in the range 0 - maxDwellTime
     if (timeToHop)
       hopChannel();
-    uint16_t msToNextHop = settings.maxDwellTime - (millis() - timerStart);
+    uint16_t msToNextHop = settings.maxDwellTime - (millis() - channelTimerStart); //TX channel timer value
     memcpy(header, &msToNextHop, sizeof(msToNextHop));
     header += sizeof(msToNextHop); //aka CHANNEL_TIMER_BYTES
 
@@ -2907,7 +2907,7 @@ void startChannelTimer(int16_t startAmount)
   channelTimer.disableTimer();
   channelTimer.setInterval_MS(startAmount, channelTimerHandler);
   channelTimer.enableTimer();
-  timerStart = millis(); //ISR normally takes care of this but allow for correct ACK sync before first ISR
+  channelTimerStart = millis(); //startChannelTimer - ISR updates value
   triggerEvent(TRIGGER_HOP_TIMER_START);
 }
 
@@ -2973,7 +2973,7 @@ void syncChannelTimer()
   //Determine if the remote system has hopped and the local system has not
   deltaHops = 0;
   deltaMillis = msToNextHopRemote - txRxTimeMsec;
-  if ((deltaMillis <= 0) && ((currentMillis - timerStart) > (settings.maxDwellTime - txRxTimeMsec)))
+  if ((deltaMillis <= 0) && ((currentMillis - channelTimerStart) > (settings.maxDwellTime - txRxTimeMsec)))
   {
     //Hop one channel to catch up with the remote system
 //    hopChannel();
@@ -3035,7 +3035,7 @@ void syncChannelTimer()
       break;
   }
 
-  int16_t msToNextHopLocal = settings.maxDwellTime - (millis() - timerStart);
+  int16_t msToNextHopLocal = settings.maxDwellTime - (millis() - channelTimerStart);
 
   //Precalculate large/small time amounts
   uint16_t smallAmount = settings.maxDwellTime / 8;

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -725,7 +725,7 @@ void updateHopISR()
 //We adjust the initial clock setup as needed
 int16_t getLinkupOffset()
 {
-  partialTimer = true; //Mark timer so that it runs only once with less than dwell time
+  reloadChannelTimer = true; //Mark timer so that it runs only once with less than dwell time
 
   int linkupOffset = 0;
 
@@ -2919,7 +2919,7 @@ void stopChannelTimer()
   channelTimer.disableTimer();
   triggerEvent(TRIGGER_HOP_TIMER_STOP);
   timeToHop = false;
-  partialTimer = false;
+  reloadChannelTimer = false;
 }
 
 //Given the remote unit's number of ms before its next hop,
@@ -3116,7 +3116,8 @@ void syncChannelTimer()
   while (msToNextHop < 0)
     msToNextHop += settings.maxDwellTime;
 
-  partialTimer = true;
+  //When the ISR fires, reload the channel timer with settings.maxDwellTime
+  reloadChannelTimer = true;
   channelTimer.disableTimer();
   channelTimer.setInterval_MS(msToNextHop, channelTimerHandler); //Adjust our hardware timer to match our mate's
 

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -2976,8 +2976,7 @@ void syncChannelTimer()
   if ((deltaMillis <= 0) && ((currentMillis - timerStart) > (settings.maxDwellTime - txRxTimeMsec)))
   {
     //Hop one channel to catch up with the remote system
-    if (allowAdjustments)
-      hopChannel();
+//    hopChannel();
     deltaHops -= 1;
   }
 

--- a/Firmware/LoRaSerial_Firmware/States.ino
+++ b/Firmware/LoRaSerial_Firmware/States.ino
@@ -240,21 +240,21 @@ void updateRadioState()
                        |                         |   Start Rx              |   |
                        |                         |   MAX_PACKET_SIZE       |   |
                        |                         |                         |   |
-                       V                         V         Timeout         |   |
-      .--------------->+                P2P_WAIT_ZERO_ACKS ----------------'   |
-      |                |                         |                             |
-      |                | TX ZERO_ACKS            |                             |
-      |                |                         |                             |
-      |                V                         |                             |
-      |    P2P_WAIT_TX_ZERO_ACKS_DONE            |                             |
-      |                | Tx Complete - - - - - > | Rx ZERO_ACKS                |
-      | Stop           |   Start HOP timer       |   Start HOP Timer           |
-      | HOP            |   Start Rx              |   Start Rx                  |
-      | Timer          |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE           |
-      |                |   Zero ACKs             |   Zero ACKs                 |
-      |       Rx       |                         |                             |
-      |    SYNC_CLOCKS V                         V         Rx FIND_PARTNER     |
-      `---------- P2P_LINK_UP               P2P_LINK_UP -----------------------’
+                       |                         V         Timeout         |   |
+                       |                P2P_WAIT_ZERO_ACKS ----------------'   |
+                       |                         |                             |
+                       | TX ZERO_ACKS            |                             |
+                       |                         |                             |
+                       V                         |                             |
+           P2P_WAIT_TX_ZERO_ACKS_DONE            |                             |
+                       | Tx Complete - - - - - > | Rx ZERO_ACKS                |
+                       |   Start HOP timer       |   Start HOP Timer           |
+                       |   Start Rx              |   Start Rx                  |
+                       |   MAX_PACKET_SIZE       |   MAX_PACKET_SIZE           |
+                       |   Zero ACKs             |   Zero ACKs                 |
+                       |                         |                             |
+                       V                         V         Rx FIND_PARTNER     |
+                  P2P_LINK_UP               P2P_LINK_UP -----------------------’
                        |                         |
                        | Rx Data                 | Rx Data
                        |                         |
@@ -672,6 +672,8 @@ void updateRadioState()
             }
             break;
 
+          case DATAGRAM_SYNC_CLOCKS:
+          case DATAGRAM_ZERO_ACKS:
           case DATAGRAM_BAD:
             triggerEvent(TRIGGER_BAD_PACKET);
             break;


### PR DESCRIPTION
Define a single source for channelTimer corrections

For point-to-point mode the source for channel timer corrections is the system that sent the DATAGRAM_SYNC_CLOCKS frame.  The other system is the only system that updates its timer.

For multi-point and virtual-circuit modes the server is the source for channel timer corrections.  The client systems all synchronize to the server.