### PR TITLE
Start hopping channels with TX/RX of SYNC_CLOCKS

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Begin.ino
+++ b/Firmware/LoRaSerial_Firmware/Begin.ino
@@ -100,13 +100,17 @@ void channelTimerHandler()
   channelTimerStart = millis(); //Record when this ISR happened. Used for calculating clock sync.
   radioCallHistory[RADIO_CALL_channelTimerHandler] = channelTimerStart;
 
-  //Restore the full timer interval
-  channelTimer.setInterval_MS(settings.maxDwellTime, channelTimerHandler);
-  channelTimerMsec = settings.maxDwellTime; //ISR update
-  digitalWrite(pin_hop_timer, channelNumber & 1);
+  //If the last timer was used to sync clocks, restore full timer interval
+  if (reloadChannelTimer == true)
+  {
+    reloadChannelTimer = false;
+    channelTimer.setInterval_MS(settings.maxDwellTime, channelTimerHandler);
+    channelTimerMsec = settings.maxDwellTime; //ISR update
+  }
 
   if (settings.frequencyHop)
   {
+    digitalWrite(pin_hop_timer, ((channelNumber + 1) % settings.numberOfChannels) & 1);
     triggerEvent(TRIGGER_CHANNEL_TIMER_ISR);
     timeToHop = true;
   }

--- a/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
+++ b/Firmware/LoRaSerial_Firmware/LoRaSerial_Firmware.ino
@@ -170,6 +170,7 @@ SAMDTimer channelTimer(TIMER_TCC); //Available: TC3, TC4, TC5, TCC, TCC1 or TCC2
 volatile uint16_t channelTimerMsec; //Last value programmed into the channel timer
 volatile unsigned long channelTimerStart = 0; //Tracks how long our timer has been running since last hop
 volatile bool timeToHop = false; //Set by channelTimerHandler to indicate that hopChannel needs to be called
+volatile bool reloadChannelTimer = false; //When set channel timer interval needs to be reloaded with settings.maxDwellTime
 
 uint16_t petTimeout = 0; //A reduced amount of time before WDT triggers. Helps reduce amount of time spent petting.
 unsigned long lastPet = 0; //Remebers time of last WDT pet.
@@ -585,6 +586,7 @@ char platformPrefix[25]; //Used for printing platform specific device name, ie "
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 bool clockSyncReceiver; //Receives and processes the clock synchronization
+bool startChannelTimerPending; //When true, call startChannelTimer in transactionCompleteISR
 
 //RX and TX time measurements
 uint32_t rxTimeUsec;


### PR DESCRIPTION
Set the initial clock synchronization at less than a millisecond.  The separation of the TX and RX transactionComplete interrupts is around 650 - 700 uSec.  By letting the transactionCompleteISR routine call startChannelTimer, the first expire time of the two timers is within 1 millisecond.

The transmit completion routine for SYNC_CLOCKS and the receive routine for SYNC_CLOCKS both call hopChannel to change to the next frequency.  This ensures that the two radios start hopping as soon as they are synchronized.