### PR TITLE
Set txSetChannelTimerMicros even when frequencyHop is false

### DIFF
--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -2683,6 +2683,8 @@ bool transmitDatagram()
         hopChannel();
     }
   }
+  else
+    txSetChannelTimerMicros = micros();
 
   /*
                           Header ------.           endOfTxData ---.

--- a/Firmware/LoRaSerial_Firmware/Radio.ino
+++ b/Firmware/LoRaSerial_Firmware/Radio.ino
@@ -3154,7 +3154,7 @@ bool getTxTime(bool (*transmitFrame)(), uint32_t * txFrameUsec, const char * fra
     systemPrint("TX ");
     systemPrint(frameName);
     systemPrint(": ");
-    systemPrint(*txFrameUsec);
+    systemPrint(((float)*txFrameUsec) / 1000., 5);
     systemPrintln(" mSec");
     outputSerialData(true);
   }


### PR DESCRIPTION
Enable the proper calculation of TX time for the various frames