### PR TITLE
Intro: Update the introduction to point at the quick start guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Introduction
 
-Out of the box, the SparkFun LoRaSerial products are simple-to-use serial radios and can be used with little or no configuration. This Product Manual provides detailed descriptions of all the available features of the LoRaSerial products.
+Out of the box, the SparkFun LoRaSerial products are simple-to-use point-to-point serial radio pair and can be used with little or no configuration. This [Product Manual](http://docs.sparkfun.com/SparkFun_LoRaSerial/quick_start/) provides detailed descriptions of all the available features of the LoRaSerial products.
 
-The line of LoRaSerial products offered by SparkFun all run identical firmware. The [LoRaSerial](https://github.com/sparkfun/SparkFun_LoRaSerial) and this guide cover the following products:
+The line of LoRaSerial products offered by SparkFun all run identical firmware. The [LoRaSerial repo](https://github.com/sparkfun/SparkFun_LoRaSerial) and this guide cover the following products:
 
 <table class="table table-hover table-striped table-bordered">
   <tr align="center">

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Out of the box, the SparkFun LoRaSerial products are simple-to-use serial radios and can be used with little or no configuration. This Product Manual provides detailed descriptions of all the available features of the LoRaSerial products.
+Out of the box, the SparkFun LoRaSerial products are simple-to-use point-to-point serial radio pair and can be used with little or no configuration. This [Product Manual](http://docs.sparkfun.com/SparkFun_LoRaSerial/quick_start/) provides detailed descriptions of all the available features of the LoRaSerial products.
 
 The line of LoRaSerial products offered by SparkFun all run identical firmware. The [LoRaSerial repo](https://github.com/sparkfun/SparkFun_LoRaSerial) and this guide cover the following products:
 


### PR DESCRIPTION
# Introduction

Out of the box, the SparkFun LoRaSerial products are simple-to-use point-to-point serial radio pair and can be used with little or no configuration. This [Product Manual](http://docs.sparkfun.com/SparkFun_LoRaSerial/quick_start/) provides detailed descriptions of all the available features of the LoRaSerial products.

The line of LoRaSerial products offered by SparkFun all run identical firmware. The [LoRaSerial repo](https://github.com/sparkfun/SparkFun_LoRaSerial) and this guide cover the following products:

<table class="table table-hover table-striped table-bordered">
  <tr align="center">
   <td><a href="https://www.sparkfun.com/products/19311"><img src="https://cdn.sparkfun.com//assets/parts/1/8/9/4/0/19311-SparkFun_LoRaSerial_Kit_-_915MHz-01.jpg"></a></td>
   <td><a href="https://www.sparkfun.com/products/20029"><img src="https://cdn.sparkfun.com//assets/parts/1/8/9/4/0/19311-SparkFun_LoRaSerial_Kit_-_915MHz-01.jpg"></a></td>
  </tr>
  <tr align="center">
    <td><a href="https://www.sparkfun.com/products/19311">SparkFun LoRaSerial Kit - 915MHz (WRL-19311)</a></td>
    <td><a href="https://www.sparkfun.com/products/20029">SparkFun LoRaSerial Enclosed Kit - 915MHz (WRL-20029)</a></td>
  </tr>
</table>

If you have an issue, feature request, bug report, or a general question about the LoRaSerial firmware specifically we encourage you to post your comments on the [firmware's repository](https://github.com/sparkfun/SparkFun_LoRaSerial/issues).
