### PR TITLE
Don't save the training server parameters

### DIFF
--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -199,17 +199,7 @@ bool commandAT(const char * commandString)
         }
 
         reportOK();
-        if (serialOperatingMode == MODE_VIRTUAL_CIRCUIT)
-        {
-          //Notify the PC of the serial port failure
-          serialOutputByte(START_OF_VC_SERIAL);
-          serialOutputByte(3);
-          serialOutputByte(PC_SERIAL_RECONNECT);
-          serialOutputByte(myVc);
-        }
-        outputSerialData(true);
-        systemFlush();
-        systemReset();
+        commandReset();
         return true;
     }
   }
@@ -852,6 +842,7 @@ void reportOK()
   commandComplete(true);
 }
 
+//Notify the host that the command is complete
 void commandComplete(bool success)
 {
   if (settings.operatingMode == MODE_VIRTUAL_CIRCUIT)
@@ -865,6 +856,22 @@ void commandComplete(bool success)
     //Output the command complete message
     systemWrite(success ? VC_CMD_SUCCESS : VC_CMD_ERROR);
   }
+}
+
+//Notify the host of the reset then reboot the system
+void commandReset()
+{
+  if (serialOperatingMode == MODE_VIRTUAL_CIRCUIT)
+  {
+    //Notify the PC of the serial port failure
+    serialOutputByte(START_OF_VC_SERIAL);
+    serialOutputByte(3);
+    serialOutputByte(PC_SERIAL_RECONNECT);
+    serialOutputByte(myVc);
+  }
+  outputSerialData(true);
+  systemFlush();
+  systemReset();
 }
 
 //Remove any preceeding or following whitespace chars

--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -183,7 +183,7 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('T'): //ATT - Enter training mode
-        settings = tempSettings; //Apply user's modifications
+        trainingSettings = tempSettings; //Apply user's modifications
         selectTraining();
         return true;
 

--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -145,7 +145,7 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('G'): //ATG - Generate a new netID and encryption key
-        generateRandomKeysID();
+        generateRandomKeysID(&tempSettings);
         return true;
 
       case ('I'): //ATI

--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -487,7 +487,6 @@ bool trainingPreviousRxInProgress = false; //Previous RX status
 float originalChannel; //Original channel from HOP table while training is in progress
 uint8_t trainingPartnerID[UNIQUE_ID_BYTES]; //Unique ID of the training partner
 uint8_t myUniqueId[UNIQUE_ID_BYTES]; // Unique ID of this system
-unsigned long trainingTimer;
 
 //Virtual-Circuit
 int8_t cmdVc;   //VC index for ATI commands only

--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -509,7 +509,8 @@ unsigned long retransmitTimeout = 0; //Throttle back re-transmits
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 const Settings defaultSettings;
 Settings settings; //Active settings used by the radio
-Settings tempSettings; //Create a duplicate of settings during training so that we can resort as needed
+Settings tempSettings; //Temporary settings used for command processing
+Settings trainingSettings; //Settings used for training other radios
 
 char platformPrefix[25]; //Used for printing platform specific device name, ie "SAMD21 1W 915MHz"
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -509,6 +509,7 @@ unsigned long retransmitTimeout = 0; //Throttle back re-transmits
 //Global variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 const Settings defaultSettings;
+Settings settings; //Active settings used by the radio
 Settings tempSettings; //Create a duplicate of settings during training so that we can resort as needed
 
 char platformPrefix[25]; //Used for printing platform specific device name, ie "SAMD21 1W 915MHz"

--- a/Firmware/LoRaSerial/Radio.ino
+++ b/Firmware/LoRaSerial/Radio.ino
@@ -1237,88 +1237,88 @@ void updateRadioParameters(uint8_t * rxData)
   memcpy(&params, rxData, sizeof(params));
 
   //Update the radio parameters
-  tempSettings.autoTuneFrequency = params.autoTuneFrequency;
-  tempSettings.frequencyHop = params.frequencyHop;
-  tempSettings.frequencyMax = params.frequencyMax;
-  tempSettings.frequencyMin = params.frequencyMin;
-  tempSettings.maxDwellTime = params.maxDwellTime;
-  tempSettings.numberOfChannels = params.numberOfChannels;
-  tempSettings.radioBandwidth = params.radioBandwidth;
-  tempSettings.radioBroadcastPower_dbm = params.radioBroadcastPower_dbm;
-  tempSettings.radioCodingRate = params.radioCodingRate;
-  tempSettings.radioPreambleLength = params.radioPreambleLength;
-  tempSettings.radioSpreadFactor = params.radioSpreadFactor;
-  tempSettings.radioSyncWord = params.radioSyncWord;
-  tempSettings.txToRxUsec = params.txToRxUsec;
+  trainingSettings.autoTuneFrequency = params.autoTuneFrequency;
+  trainingSettings.frequencyHop = params.frequencyHop;
+  trainingSettings.frequencyMax = params.frequencyMax;
+  trainingSettings.frequencyMin = params.frequencyMin;
+  trainingSettings.maxDwellTime = params.maxDwellTime;
+  trainingSettings.numberOfChannels = params.numberOfChannels;
+  trainingSettings.radioBandwidth = params.radioBandwidth;
+  trainingSettings.radioBroadcastPower_dbm = params.radioBroadcastPower_dbm;
+  trainingSettings.radioCodingRate = params.radioCodingRate;
+  trainingSettings.radioPreambleLength = params.radioPreambleLength;
+  trainingSettings.radioSpreadFactor = params.radioSpreadFactor;
+  trainingSettings.radioSyncWord = params.radioSyncWord;
+  trainingSettings.txToRxUsec = params.txToRxUsec;
 
   //Update the radio protocol parameters
-  tempSettings.dataScrambling = params.dataScrambling;
-  tempSettings.enableCRC16 = params.enableCRC16;
-  tempSettings.encryptData = params.encryptData;
-  memcpy(tempSettings.encryptionKey, params.encryptionKey, sizeof(tempSettings.encryptionKey));
-  tempSettings.framesToYield = params.framesToYield;
-  tempSettings.heartbeatTimeout = params.heartbeatTimeout;
-  tempSettings.maxResends = params.maxResends;
-  tempSettings.netID = params.netID;
-  tempSettings.operatingMode = params.operatingMode;
-  tempSettings.overheadTime = params.overheadTime;
-  tempSettings.selectLedUse = params.selectLedUse;
-  tempSettings.server = params.server;
-  tempSettings.verifyRxNetID = params.verifyRxNetID;
+  trainingSettings.dataScrambling = params.dataScrambling;
+  trainingSettings.enableCRC16 = params.enableCRC16;
+  trainingSettings.encryptData = params.encryptData;
+  memcpy(trainingSettings.encryptionKey, params.encryptionKey, sizeof(trainingSettings.encryptionKey));
+  trainingSettings.framesToYield = params.framesToYield;
+  trainingSettings.heartbeatTimeout = params.heartbeatTimeout;
+  trainingSettings.maxResends = params.maxResends;
+  trainingSettings.netID = params.netID;
+  trainingSettings.operatingMode = params.operatingMode;
+  trainingSettings.overheadTime = params.overheadTime;
+  trainingSettings.selectLedUse = params.selectLedUse;
+  trainingSettings.server = params.server;
+  trainingSettings.verifyRxNetID = params.verifyRxNetID;
 
   //Update the debug parameters
   if (params.copyDebug)
   {
-    tempSettings.copyDebug = params.copyDebug;
-    tempSettings.debug = params.debug;
-    tempSettings.debugDatagrams = params.debugDatagrams;
-    tempSettings.debugHeartbeat = params.debugHeartbeat;
-    tempSettings.debugNvm = params.debugNvm;
-    tempSettings.debugRadio = params.debugRadio;
-    tempSettings.debugReceive = params.debugReceive;
-    tempSettings.debugSerial = params.debugSerial;
-    tempSettings.debugStates = params.debugStates;
-    tempSettings.debugSync = params.debugSync;
-    tempSettings.debugTraining = params.debugTraining;
-    tempSettings.debugTransmit = params.debugTransmit;
-    tempSettings.displayRealMillis = params.displayRealMillis;
-    tempSettings.printAckNumbers = params.printAckNumbers;
-    tempSettings.printChannel = params.printChannel;
-    tempSettings.printFrequency = params.printFrequency;
-    tempSettings.printLinkUpDown = params.printLinkUpDown;
-    tempSettings.printPacketQuality = params.printPacketQuality;
-    tempSettings.printPktData = params.printPktData;
-    tempSettings.printRfData = params.printRfData;
-    tempSettings.printTimestamp = params.printTimestamp;
-    tempSettings.printTxErrors = params.printTxErrors;
+    trainingSettings.copyDebug = params.copyDebug;
+    trainingSettings.debug = params.debug;
+    trainingSettings.debugDatagrams = params.debugDatagrams;
+    trainingSettings.debugHeartbeat = params.debugHeartbeat;
+    trainingSettings.debugNvm = params.debugNvm;
+    trainingSettings.debugRadio = params.debugRadio;
+    trainingSettings.debugReceive = params.debugReceive;
+    trainingSettings.debugSerial = params.debugSerial;
+    trainingSettings.debugStates = params.debugStates;
+    trainingSettings.debugSync = params.debugSync;
+    trainingSettings.debugTraining = params.debugTraining;
+    trainingSettings.debugTransmit = params.debugTransmit;
+    trainingSettings.displayRealMillis = params.displayRealMillis;
+    trainingSettings.printAckNumbers = params.printAckNumbers;
+    trainingSettings.printChannel = params.printChannel;
+    trainingSettings.printFrequency = params.printFrequency;
+    trainingSettings.printLinkUpDown = params.printLinkUpDown;
+    trainingSettings.printPacketQuality = params.printPacketQuality;
+    trainingSettings.printPktData = params.printPktData;
+    trainingSettings.printRfData = params.printRfData;
+    trainingSettings.printTimestamp = params.printTimestamp;
+    trainingSettings.printTxErrors = params.printTxErrors;
   }
 
   //Update the serial parameters
   if (params.copySerial)
   {
-    tempSettings.copySerial = params.copySerial;
-    tempSettings.echo = params.echo;
-    tempSettings.flowControl = params.flowControl;
-    tempSettings.invertCts = params.invertCts;
-    tempSettings.invertRts = params.invertRts;
-    tempSettings.serialSpeed = params.serialSpeed;
-    tempSettings.serialTimeoutBeforeSendingFrame_ms = params.serialTimeoutBeforeSendingFrame_ms;
-    tempSettings.usbSerialWait = params.usbSerialWait;
+    trainingSettings.copySerial = params.copySerial;
+    trainingSettings.echo = params.echo;
+    trainingSettings.flowControl = params.flowControl;
+    trainingSettings.invertCts = params.invertCts;
+    trainingSettings.invertRts = params.invertRts;
+    trainingSettings.serialSpeed = params.serialSpeed;
+    trainingSettings.serialTimeoutBeforeSendingFrame_ms = params.serialTimeoutBeforeSendingFrame_ms;
+    trainingSettings.usbSerialWait = params.usbSerialWait;
   }
 
   //Update the training values
-  tempSettings.clientFindPartnerRetryInterval = params.clientFindPartnerRetryInterval;
+  trainingSettings.clientFindPartnerRetryInterval = params.clientFindPartnerRetryInterval;
   //The trainingKey is already the same
-  tempSettings.trainingTimeout = params.trainingTimeout;
+  trainingSettings.trainingTimeout = params.trainingTimeout;
 
   //Update the trigger parameters
   if (params.copyTriggers)
   {
-    tempSettings.copyTriggers = params.copyTriggers;
-    tempSettings.triggerEnable = params.triggerEnable;
-    tempSettings.triggerEnable2 = params.triggerEnable2;
-    tempSettings.triggerWidth = params.triggerWidth;
-    tempSettings.triggerWidthIsMultiplier = params.triggerWidthIsMultiplier;
+    trainingSettings.copyTriggers = params.copyTriggers;
+    trainingSettings.triggerEnable = params.triggerEnable;
+    trainingSettings.triggerEnable2 = params.triggerEnable2;
+    trainingSettings.triggerWidth = params.triggerWidth;
+    trainingSettings.triggerWidthIsMultiplier = params.triggerWidthIsMultiplier;
   }
 }
 
@@ -1334,7 +1334,7 @@ bool xmitDatagramTrainRadioParameters(const uint8_t * clientID)
   radioCallHistory[RADIO_CALL_xmitDatagramTrainRadioParameters] = millis();
 
   //Initialize the radio parameters
-  memcpy(&params, &tempSettings, sizeof(settings));
+  memcpy(&params, &trainingSettings, sizeof(settings));
   params.server = false;
 
   //Add the destination (client) ID

--- a/Firmware/LoRaSerial/States.ino
+++ b/Firmware/LoRaSerial/States.ino
@@ -1722,9 +1722,7 @@ void updateRadioState()
                   && tempSettings.server == false)
               {
                 //Reboot the radio with the newly generated random netID/Key parameters
-                petWDT();
-                systemFlush();
-                systemReset();
+                commandReset;
               }
             }
             break;

--- a/Firmware/LoRaSerial/System.ino
+++ b/Firmware/LoRaSerial/System.ino
@@ -268,6 +268,7 @@ void updateButton()
       trainState = TRAIN_PRESSED;
 
       trainViaButton = true;
+      trainingSettings = settings;
       selectTraining();
     }
     else if (trainState == TRAIN_PRESSED && trainBtn->wasReleased())
@@ -276,7 +277,7 @@ void updateButton()
     }
     else if (trainState == TRAIN_IN_PROCESS && trainBtn->wasReleased())
     {
-      settings = tempSettings; //Return to original radio settings
+      settings = trainingSettings; //Return to original radio settings
 
       recordSystemSettings(); //Record original settings
 

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -67,11 +67,8 @@ void beginTrainingClient()
 //Start the training in server mode
 void beginTrainingServer()
 {
-  trainingServerRunning = true;
-
-  //Record the settings used for training
   petWDT();
-  recordSystemSettings();
+  trainingServerRunning = true;
 
   //Display the values to be used for the client/server training
   systemPrintln("Server training parameters");

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -103,9 +103,6 @@ void beginTrainingServer()
 //Perform the common training initialization
 void commonTrainingInitialization()
 {
-  //Save the current settings
-  trainingSettings = settings;
-
   //Use common radio settings between the client and server for training
   settings = defaultSettings;
   settings.dataScrambling = true;           //Scramble the data

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -10,7 +10,7 @@ void selectTraining()
 //Generate new netID/AES key to share
 //We assume the user needs to maintain their settings (airSpeed, numberOfChannels, freq min/max, bandwidth/spread/hop)
 //but need to be on a different netID/AES key.
-void generateRandomKeysID()
+void generateRandomKeysID(Settings * radioSettings)
 {
   if ((settings.debug == true) || (settings.debugTraining == true))
   {
@@ -22,24 +22,24 @@ void generateRandomKeysID()
   randomSeed(radio.randomByte());
 
   //Generate new NetID
-  settings.netID = random(0, 256); //Inclusive, exclusive
+  radioSettings->netID = random(0, 256); //Inclusive, exclusive
 
   //Generate new AES Key. User may not be using AES but we still need both radios to have the same key in case they do enable AES.
   for (int x = 0 ; x < 16 ; x++)
-    settings.encryptionKey[x] = random(0, 256); //Inclusive, exclusive
+    radioSettings->encryptionKey[x] = random(0, 256); //Inclusive, exclusive
 
   //We do not generate new AES Initial Values here. Those are generated during generateHopTable() based on the unit's settings.
 
   if ((settings.debug == true) || (settings.debugTraining == true))
   {
     systemPrint("Select new NetID: ");
-    systemPrintln(settings.netID);
+    systemPrintln(radioSettings->netID);
 
     systemPrint("Select new Encryption Key:");
     for (uint8_t i = 0 ; i < 16 ; i++)
     {
       systemPrint(" ");
-      systemPrint(settings.encryptionKey[i], HEX);
+      systemPrint(radioSettings->encryptionKey[i], HEX);
     }
     systemPrintln();
     outputSerialData(true);

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -205,7 +205,5 @@ void endClientServerTraining(uint8_t event)
   trainingServerRunning = false;
 
   //Reboot the radio with the new parameters
-  petWDT();
-  systemFlush();
-  systemReset();
+  commandReset();
 }

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -62,7 +62,6 @@ void beginTrainingClient()
     changeState(RADIO_TRAIN_WAIT_TX_FIND_PARTNER_DONE);
   else
     changeState(RADIO_TRAIN_WAIT_RX_RADIO_PARAMETERS);
-  trainingTimer = millis();
 }
 
 //Start the training in server mode

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -87,9 +87,9 @@ void beginTrainingServer()
 
   systemPrintln("Server radio protocol parameters");
   systemPrint("  netID: ");
-  systemPrintln(tempSettings.netID);
+  systemPrintln(trainingSettings.netID);
   systemPrint("  Encryption key: ");
-  displayEncryptionKey(tempSettings.encryptionKey);
+  displayEncryptionKey(trainingSettings.encryptionKey);
   systemPrintln();
   outputSerialData(true);
 
@@ -104,14 +104,14 @@ void beginTrainingServer()
 void commonTrainingInitialization()
 {
   //Save the current settings
-  tempSettings = settings;
+  trainingSettings = settings;
 
   //Use common radio settings between the client and server for training
   settings = defaultSettings;
   settings.dataScrambling = true;           //Scramble the data
   settings.enableCRC16 = true;              //Use CRC-16
   settings.encryptData = true;              //Enable packet encryption
-  memcpy(&settings.encryptionKey, &tempSettings.trainingKey, AES_KEY_BYTES); //Common encryption key
+  memcpy(&settings.encryptionKey, &trainingSettings.trainingKey, AES_KEY_BYTES); //Common encryption key
   settings.frequencyHop = false;            //Stay on the training frequency
   settings.maxResends = 1;                  //Don't waste time retransmitting
   settings.netID = 'T';                     //NetID for training
@@ -124,37 +124,37 @@ void commonTrainingInitialization()
   selectHeaderAndTrailerBytes();
 
   //Debug training if requested
-  if (tempSettings.debugTraining)
+  if (trainingSettings.debugTraining)
   {
-    settings.selectLedUse = tempSettings.selectLedUse;
+    settings.selectLedUse = trainingSettings.selectLedUse;
     //Ignore copyDebug
-    settings.debug = tempSettings.debug;
-    settings.debugDatagrams = tempSettings.debugDatagrams;
-    settings.debugHeartbeat = tempSettings.debugHeartbeat;
-    settings.debugNvm = tempSettings.debugNvm;
-    settings.debugRadio = tempSettings.debugRadio;
-    settings.debugReceive = tempSettings.debugReceive;
-    settings.debugSerial = tempSettings.debugSerial;
-    settings.debugStates = tempSettings.debugStates;
-    settings.debugSync = tempSettings.debugSync;
-    settings.debugTraining = tempSettings.debugTraining;
-    settings.debugTransmit = tempSettings.debugTransmit;
-    settings.displayRealMillis = tempSettings.displayRealMillis;
-    settings.printAckNumbers = tempSettings.printAckNumbers;
-    settings.printChannel = tempSettings.printChannel;
-    settings.printFrequency = tempSettings.printFrequency;
-    settings.printLinkUpDown = tempSettings.printLinkUpDown;
-    settings.printPacketQuality = tempSettings.printPacketQuality;
-    settings.printPktData = tempSettings.printPktData;
-    settings.printRfData = tempSettings.printRfData;
-    settings.printTimestamp = tempSettings.printTimestamp;
-    settings.printTxErrors = tempSettings.printTxErrors;
+    settings.debug = trainingSettings.debug;
+    settings.debugDatagrams = trainingSettings.debugDatagrams;
+    settings.debugHeartbeat = trainingSettings.debugHeartbeat;
+    settings.debugNvm = trainingSettings.debugNvm;
+    settings.debugRadio = trainingSettings.debugRadio;
+    settings.debugReceive = trainingSettings.debugReceive;
+    settings.debugSerial = trainingSettings.debugSerial;
+    settings.debugStates = trainingSettings.debugStates;
+    settings.debugSync = trainingSettings.debugSync;
+    settings.debugTraining = trainingSettings.debugTraining;
+    settings.debugTransmit = trainingSettings.debugTransmit;
+    settings.displayRealMillis = trainingSettings.displayRealMillis;
+    settings.printAckNumbers = trainingSettings.printAckNumbers;
+    settings.printChannel = trainingSettings.printChannel;
+    settings.printFrequency = trainingSettings.printFrequency;
+    settings.printLinkUpDown = trainingSettings.printLinkUpDown;
+    settings.printPacketQuality = trainingSettings.printPacketQuality;
+    settings.printPktData = trainingSettings.printPktData;
+    settings.printRfData = trainingSettings.printRfData;
+    settings.printTimestamp = trainingSettings.printTimestamp;
+    settings.printTxErrors = trainingSettings.printTxErrors;
 
     //Ignore copyTriggers
-    settings.triggerEnable = tempSettings.triggerEnable;
-    settings.triggerEnable2 = tempSettings.triggerEnable2;
-    settings.triggerWidth = tempSettings.triggerWidth;
-    settings.triggerWidthIsMultiplier = tempSettings.triggerWidthIsMultiplier;
+    settings.triggerEnable = trainingSettings.triggerEnable;
+    settings.triggerEnable2 = trainingSettings.triggerEnable2;
+    settings.triggerWidth = trainingSettings.triggerWidth;
+    settings.triggerWidthIsMultiplier = trainingSettings.triggerWidthIsMultiplier;
   }
 
   //Reset cylon variables
@@ -180,7 +180,7 @@ void commonTrainingInitialization()
 void endClientServerTraining(uint8_t event)
 {
   triggerEvent(event);
-  settings = tempSettings; //Return to original radio settings
+  settings = trainingSettings; //Return to original radio settings
 
   if (settings.debugTraining)
   {

--- a/Firmware/LoRaSerial/settings.h
+++ b/Firmware/LoRaSerial/settings.h
@@ -19,7 +19,7 @@ typedef enum
   RADIO_DISCOVER_SCANNING,
   RADIO_DISCOVER_WAIT_TX_FIND_PARTNER_DONE,
   RADIO_DISCOVER_STANDBY,
-  
+
   //Multi-Point: Datagrams
   RADIO_MP_STANDBY,
   RADIO_MP_WAIT_TX_DONE,
@@ -518,7 +518,6 @@ typedef struct struct_settings {
   //-- Add commands to set the parameters
   //-- Add parameters to routine updateRadioParameters
 } Settings;
-Settings settings;
 
 //Monitor which devices on the device are on or offline.
 struct struct_online {


### PR DESCRIPTION
The user should save the training server parameters in command mode before entering training.  Otherwise the training parameters are considered temporary and will be discarded.