### PR TITLE
Allow white space in the command

### DIFF
--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -814,9 +814,12 @@ void checkCommand()
   int prefixLength;
   bool success;
 
-  //Verify the command length
+  //Zero terminate the string
   success = false;
-  commandString = trimCommand(); //Remove any leading or trailing whitespace
+  commandBuffer[commandLength] = 0;
+
+  //Remove any whitespace
+  commandString = trimCommand();
 
   //Upper case the command
   for (index = 0; index < commandLength; index++)
@@ -845,6 +848,8 @@ void checkCommand()
       break;
     }
   }
+  else if (!commandLength)
+    success = true;
 
   //Print the command failure
   petWDT();
@@ -903,24 +908,20 @@ void commandReset()
 //Remove any preceeding or following whitespace chars
 char * trimCommand()
 {
-  char * commandString = commandBuffer;
+  int index;
+  int j;
 
-  //Remove the leading white space
-  while (isspace(*commandString))
+  //Remove the white space
+  for (index = 0; index < commandLength; index++)
   {
-    commandString++;
-    --commandLength;
+    while (isspace(commandBuffer[index]))
+    {
+      for (j = index + 1; j < commandLength; j++)
+        commandBuffer[j - 1] = commandBuffer[j];
+      commandBuffer[--commandLength] = 0;
+    }
   }
-
-  //Zero terminate the string
-  commandString[commandLength] = 0;
-
-  //Remove the trailing white space
-  while (commandLength && isspace(commandString[commandLength - 1]))
-    commandString[--commandLength] = 0;
-
-  //Return the remainder as the command
-  return commandString;
+  return commandBuffer;
 }
 
 //Display all of the commands


### PR DESCRIPTION
Valid commands may now include space, horizontal tab(0x09), line feed (0x0a), vertical tab (0x0b), form feed (0x0c) and are terminated with a carriage return (0x0d).  These characters are removed prior to processing the command.
    
Blank lines return OK.
    
Valid commands:
    
at-netID = 1 &nbsp;&nbsp;&nbsp;translates into AT-NETID=1
a t i 1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;translates into ATI1
