### PR TITLE
MP: Discovery is also syncing the clock upon receiving HEARTBEAT frames

### DIFF
--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -64,7 +64,7 @@ const int FIRMWARE_VERSION_MINOR = 0;
 #define UNIQUE_ID_BYTES 16  //Number of bytes in the unique ID
 
 //Frame lengths
-#define MP_HEARTBEAT_BYTES      1 //Number of data bytes in the MP_HEARTBEAT frame
+#define MP_HEARTBEAT_BYTES      (sizeof(uint8_t) + sizeof(unsigned long)) //Number of data bytes in the MP_HEARTBEAT frame
 #define P2P_FIND_PARTNER_BYTES  sizeof(unsigned long) //Number of data bytes in the FIND_PARTNER frame
 #define P2P_SYNC_CLOCKS_BYTES   (sizeof(uint8_t) + sizeof(unsigned long)) //Number of data bytes in the SYNC_CLOCKS frame
 #define P2P_ZERO_ACKS_BYTES     sizeof(unsigned long) //Number of data bytes in the ZERO_ACKS frame

--- a/Firmware/LoRaSerial/Radio.ino
+++ b/Firmware/LoRaSerial/Radio.ino
@@ -931,8 +931,7 @@ bool xmitDatagramP2PSyncClocks()
   radioCallHistory[RADIO_CALL_xmitDatagramP2PSyncClocks] = currentMillis;
 
   startOfData = endOfTxData;
-  memcpy(endOfTxData, &channelNumber, sizeof(channelNumber));
-  endOfTxData += sizeof(channelNumber);
+  *endOfTxData++ = channelNumber;
 
   memcpy(endOfTxData, &currentMillis, sizeof(currentMillis));
   endOfTxData += sizeof(unsigned long);
@@ -1149,18 +1148,20 @@ bool xmitDatagramMpHeartbeat()
   radioCallHistory[RADIO_CALL_xmitDatagramMpHeartbeat] = millis();
 
   startOfData = endOfTxData;
-  memcpy(endOfTxData, &channelNumber, sizeof(channelNumber));
-  endOfTxData += sizeof(channelNumber);
+  *endOfTxData++ = channelNumber;
+
+  memcpy(endOfTxData, &currentMillis, sizeof(currentMillis));
+  endOfTxData += sizeof(unsigned long);
 
   /*
-                                              endOfTxData ---.
-                                                             |
-                                                             V
-      +----------+---------+----------+------------+---------+----------+
-      | Optional |         | Optional | Optional   | Channel |          |
-      | NET ID   | Control | C-Timer  | SF6 Length | Number  | Trailer  |
-      | 8 bits   | 8 bits  | 2 bytes  | 8 bits     | 1 byte  | n Bytes  |
-      +----------+---------+----------+------------+---------+----------+
+                                                        endOfTxData ---.
+                                                                       |
+                                                                       V
+      +----------+---------+----------+------------+---------+---------+----------+
+      | Optional |         | Optional | Optional   | Channel |         |          |
+      | NET ID   | Control | C-Timer  | SF6 Length | Number  | Millis  | Trailer  |
+      | 8 bits   | 8 bits  | 2 bytes  | 8 bits     | 1 byte  | 4 bytes | n Bytes  |
+      +----------+---------+----------+------------+---------+---------+----------+
   */
 
   //Verify the data length

--- a/Firmware/LoRaSerial/States.ino
+++ b/Firmware/LoRaSerial/States.ino
@@ -1305,7 +1305,6 @@ void updateRadioState()
               startChannelTimer();
               channelTimerStart -= settings.maxDwellTime;
               syncChannelTimer(txSyncClocksUsec);
-              triggerEvent(TRIGGER_RX_SYNC_CLOCKS);
 
               if (settings.debugSync)
               {


### PR DESCRIPTION
The MP_HEARTBEAT frame did not include the millis field.  Add the millis field to the MP_HEARTBEAT frame to enable the clock to properly synchronize.  Prior to adding this field the synchronization would be random and typically larger than 40 mSec.  With the millis value in the HEARTBEAT frame the clock synchronization drops to less than 2 mSec.

Testing was done by modifying the discovery code to save the millis value when the code transitioned to the RADIO_MP_STANDBY state.  In the RADIO_MP_STANDBY if the client had run more than 5 seconds then it would change states to RADIO_DISCOVER_BEGIN.  A five minute log was captured and the following clock synchronization offsets were recorded:

759 uSec - from HEARTBEAT frame
431 uSec - from HEARTBEAT frame
405 uSec - from HEARTBEAT frame
240 uSec - from HEARTBEAT frame
258 uSec - from HEARTBEAT frame
 79 uSec - from HEARTBEAT frame
145 uSec - from HEARTBEAT frame
663 uSec - from HEARTBEAT frame
131 uSec - from HEARTBEAT frame
370 uSec - from HEARTBEAT frame
410 uSec - from HEARTBEAT frame
438 uSec - from HEARTBEAT frame
344 uSec - from HEARTBEAT frame
564 uSec - from HEARTBEAT frame
668 uSec - from HEARTBEAT frame

The scope was setup to record 10 GSamples at 1 MHz.  D0 and D2 are connected to the server and D1 and D3 are connected to the client.

The trigger parameters were:

triggerWidth = 10;
triggerWidthIsMultiplier = true;
triggerEnable = 127;

TRIGGER_TRANSACTION_COMPLETE, //14
TRIGGER_CHANNEL_TIMER_ISR, //24
TRIGGER_RX_SYNC_CLOCKS, //34
TRIGGER_TX_SYNC_CLOCKS, //44

TRIGGER_RX_HEARTBEAT, //54
TRIGGER_TX_HEARTBEAT, //64
TRIGGER_SYNC_CHANNEL_TIMER, //74