### PR TITLE
MP: Add clock sync support for 150 BPS

### DIFF
--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -64,7 +64,7 @@ const int FIRMWARE_VERSION_MINOR = 0;
 #define UNIQUE_ID_BYTES 16  //Number of bytes in the unique ID
 
 //Frame lengths
-#define MP_HEARTBEAT_BYTES      1 //Number of data bytes in the MP_HEARTBEAT frame
+#define MP_HEARTBEAT_BYTES      (sizeof(uint8_t) + sizeof(unsigned long)) //Number of data bytes in the MP_HEARTBEAT frame
 #define P2P_FIND_PARTNER_BYTES  sizeof(unsigned long) //Number of data bytes in the FIND_PARTNER frame
 #define P2P_SYNC_CLOCKS_BYTES   (sizeof(uint8_t) + sizeof(unsigned long)) //Number of data bytes in the SYNC_CLOCKS frame
 #define P2P_ZERO_ACKS_BYTES     sizeof(unsigned long) //Number of data bytes in the ZERO_ACKS frame

--- a/Firmware/LoRaSerial/Radio.ino
+++ b/Firmware/LoRaSerial/Radio.ino
@@ -931,8 +931,7 @@ bool xmitDatagramP2PSyncClocks()
   radioCallHistory[RADIO_CALL_xmitDatagramP2PSyncClocks] = currentMillis;
 
   startOfData = endOfTxData;
-  memcpy(endOfTxData, &channelNumber, sizeof(channelNumber));
-  endOfTxData += sizeof(channelNumber);
+  *endOfTxData++ = channelNumber;
 
   memcpy(endOfTxData, &currentMillis, sizeof(currentMillis));
   endOfTxData += sizeof(unsigned long);
@@ -1149,18 +1148,20 @@ bool xmitDatagramMpHeartbeat()
   radioCallHistory[RADIO_CALL_xmitDatagramMpHeartbeat] = millis();
 
   startOfData = endOfTxData;
-  memcpy(endOfTxData, &channelNumber, sizeof(channelNumber));
-  endOfTxData += sizeof(channelNumber);
+  *endOfTxData++ = channelNumber;
+
+  memcpy(endOfTxData, &currentMillis, sizeof(currentMillis));
+  endOfTxData += sizeof(unsigned long);
 
   /*
-                                              endOfTxData ---.
-                                                             |
-                                                             V
-      +----------+---------+----------+------------+---------+----------+
-      | Optional |         | Optional | Optional   | Channel |          |
-      | NET ID   | Control | C-Timer  | SF6 Length | Number  | Trailer  |
-      | 8 bits   | 8 bits  | 2 bytes  | 8 bits     | 1 byte  | n Bytes  |
-      +----------+---------+----------+------------+---------+----------+
+                                                        endOfTxData ---.
+                                                                       |
+                                                                       V
+      +----------+---------+----------+------------+---------+---------+----------+
+      | Optional |         | Optional | Optional   | Channel |         |          |
+      | NET ID   | Control | C-Timer  | SF6 Length | Number  | Millis  | Trailer  |
+      | 8 bits   | 8 bits  | 2 bytes  | 8 bits     | 1 byte  | 4 bytes | n Bytes  |
+      +----------+---------+----------+------------+---------+---------+----------+
   */
 
   //Verify the data length

--- a/Firmware/LoRaSerial/States.ino
+++ b/Firmware/LoRaSerial/States.ino
@@ -750,7 +750,7 @@ void updateRadioState()
             COMPUTE_TIMESTAMP_OFFSET(rxData, 1, txDataAckUsec);
 
             //The datagram we are expecting
-            syncChannelTimer(txDataAckUsec); //Adjust freq hop ISR based on remote's remaining clock
+            syncChannelTimer(txDataAckUsec, 0); //Adjust freq hop ISR based on remote's remaining clock
 
             triggerEvent(TRIGGER_RX_ACK);
 
@@ -1067,9 +1067,9 @@ void updateRadioState()
       //then skip active discovery and go to standby
       if (((frameAirTimeUsec + txDataAckUsec + settings.txToRxUsec) / 1000) > (settings.maxDwellTime / 2))
       {
-        stopChannelTimer();
         channelNumber = 0;
         setRadioFrequency(false);
+        stopChannelTimer();
         changeState(RADIO_DISCOVER_STANDBY);
       }
       else
@@ -1160,7 +1160,7 @@ void updateRadioState()
               //Start and adjust freq hop ISR based on remote's remaining clock
               startChannelTimer();
               channelTimerStart -= settings.maxDwellTime;
-              syncChannelTimer(txSyncClocksUsec);
+              syncChannelTimer(txSyncClocksUsec, 1);
               triggerEvent(TRIGGER_RX_SYNC_CLOCKS);
 
               if (settings.debugSync)
@@ -1304,7 +1304,7 @@ void updateRadioState()
               //Start and adjust freq hop ISR based on remote's remaining clock
               startChannelTimer();
               channelTimerStart -= settings.maxDwellTime;
-              syncChannelTimer(txSyncClocksUsec);
+              syncChannelTimer(txSyncClocksUsec, 1);
 
               if (settings.debugSync)
               {
@@ -1422,7 +1422,7 @@ void updateRadioState()
             if (settings.server == false)
             {
               //Adjust freq hop ISR based on server's remaining clock
-              syncChannelTimer(txHeartbeatUsec);
+              syncChannelTimer(txHeartbeatUsec, 0);
 
               //Received heartbeat - do not ack.
               triggerEvent(TRIGGER_RX_HEARTBEAT);
@@ -3224,7 +3224,7 @@ void vcReceiveHeartbeat(uint32_t rxMillis)
 
   //Adjust freq hop ISR based on server's remaining clock
   if ((rxSrcVc == VC_SERVER) || (memcmp(rxVcData, myUniqueId, sizeof(myUniqueId)) == 0))
-    syncChannelTimer(txHeartbeatUsec);
+    syncChannelTimer(txHeartbeatUsec, 0);
 
   //Update the timestamp offset
   if (rxSrcVc == VC_SERVER)

--- a/Firmware/LoRaSerial/States.ino
+++ b/Firmware/LoRaSerial/States.ino
@@ -1305,7 +1305,6 @@ void updateRadioState()
               startChannelTimer();
               channelTimerStart -= settings.maxDwellTime;
               syncChannelTimer(txSyncClocksUsec);
-              triggerEvent(TRIGGER_RX_SYNC_CLOCKS);
 
               if (settings.debugSync)
               {


### PR DESCRIPTION
Rework the clock sync math to determine the number of hops that occurred during the transmitted frame.  The resulting math seems to gets the clock sync within 2 mSec.