### PR TITLE
Make operating mode and airSpeed easy to change

### DIFF
--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -130,7 +130,7 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('F'): //ATF - Restore default parameters
-        settings = defaultSettings; //Overwrite all system settings with defaults
+        getDefaultSettings(&settings); //Overwrite all system settings with defaults
 
         validateSettings(); //Modify defaults for each radio type (915, 868, 433, etc)
 

--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -1261,25 +1261,7 @@ bool valSpeedAir (void * value, uint32_t valMin, uint32_t valMax)
   UNUSED(valMin);
   UNUSED(valMax);
 
-  valid = ((settingValue == 40)
-           || (settingValue == 150)
-           || (settingValue == 400)
-           || (settingValue == 1200)
-           || (settingValue == 2400)
-           || (settingValue == 4800)
-           || (settingValue == 9600)
-           || (settingValue == 19200)
-           || (settingValue == 28800)
-           || (settingValue == 38400));
-  if (valid)
-  {
-    //Adjust the settings to match the requested airSpeed
-    convertAirSpeedToSettings(&tempSettings, settingValue);
-    airSpeed = settingValue;
-    systemPrintln("Warning: AirSpeed overrides bandwidth, coding rate, spread factor,");
-    systemPrintln("heartbeatTimeout, and txToRxUsec");
-  }
-  return valid;
+  return validateAirSpeed(&tempSettings, settingValue);
 }
 
 //Validate the SerialSpeed value

--- a/Firmware/LoRaSerial/Commands.ino
+++ b/Firmware/LoRaSerial/Commands.ino
@@ -720,19 +720,29 @@ bool commandAT(const char * commandString)
         return true;
 
       case ('1'): //ATI31 - Display the VC details
-        systemPrintTimestamp();
-        systemPrint("VC ");
-        systemPrint(cmdVc);
-        systemPrint(": ");
-        if (!vc->flags.valid)
-          systemPrintln("Down, Not valid");
+        if ((settings.operatingMode == MODE_VIRTUAL_CIRCUIT) && (!vc->flags.valid))
+        {
+          systemPrintTimestamp();
+          systemPrint("VC ");
+          systemPrint(cmdVc);
+          systemPrint(": ");
+          if (!vc->flags.valid)
+            systemPrintln("Down, Not valid");
+        }
         else
         {
-          systemPrintln(vcStateNames[vc->vcState]);
-          systemPrintTimestamp();
-          systemPrint("    ID: ");
-          systemPrintUniqueID(vc->uniqueId);
-          systemPrintln(vc->flags.valid ? " (Valid)" : " (Invalid)");
+          if (settings.operatingMode == MODE_VIRTUAL_CIRCUIT)
+          {
+            systemPrintTimestamp();
+            systemPrint("VC ");
+            systemPrint(cmdVc);
+            systemPrint(": ");
+            systemPrintln(vcStateNames[vc->vcState]);
+            systemPrintTimestamp();
+            systemPrint("    ID: ");
+            systemPrintUniqueID(vc->uniqueId);
+            systemPrintln(vc->flags.valid ? " (Valid)" : " (Invalid)");
+          }
 
           //Heartbeat metrics
           systemPrintTimestamp();
@@ -762,57 +772,60 @@ bool commandAT(const char * commandString)
           outputSerialData(true);
           petWDT();
 
-          //Transmitter metrics
-          systemPrintTimestamp();
-          systemPrintln("    Sent");
-          systemPrintTimestamp();
-          systemPrint("        Frames: ");
-          systemPrintln(vc->framesSent);
-          systemPrintTimestamp();
-          systemPrint("        Messages: ");
-          systemPrintln(vc->messagesSent);
-          outputSerialData(true);
-          petWDT();
-
-          //Receiver metrics
-          systemPrintTimestamp();
-          systemPrintln("    Received");
-          systemPrintTimestamp();
-          systemPrint("        Frames: ");
-          systemPrintln(vc->framesReceived);
-          systemPrintTimestamp();
-          systemPrint("        Messages: ");
-          systemPrintln(vc->messagesReceived);
-          systemPrintTimestamp();
-          systemPrint("        Bad Lengths: ");
-          systemPrintln(vc->badLength);
-          systemPrintTimestamp();
-          systemPrint("        Link Failures: ");
-          systemPrintln(linkFailures);
-          outputSerialData(true);
-          petWDT();
-
-          //ACK Management metrics
-          systemPrintTimestamp();
-          systemPrintln("    ACK Management");
-          systemPrintTimestamp();
-          systemPrint("        Last RX ACK number: ");
-          systemPrintln(vc->rxAckNumber);
-          systemPrintTimestamp();
-          systemPrint("        Next RX ACK number: ");
-          systemPrintln(vc->rmtTxAckNumber);
-          systemPrintTimestamp();
-          systemPrint("        Last TX ACK number: ");
-          systemPrintln(vc->txAckNumber);
-          if (txDestVc == cmdVc)
+          if ((settings.operatingMode == MODE_VIRTUAL_CIRCUIT) && (!vc->flags.valid))
           {
+            //Transmitter metrics
             systemPrintTimestamp();
-            systemPrint("        ackTimer: ");
-            if (ackTimer)
-              systemPrintTimestamp(ackTimer + timestampOffset);
-            else
-              systemPrint("Not Running");
-            systemPrintln();
+            systemPrintln("    Sent");
+            systemPrintTimestamp();
+            systemPrint("        Frames: ");
+            systemPrintln(vc->framesSent);
+            systemPrintTimestamp();
+            systemPrint("        Messages: ");
+            systemPrintln(vc->messagesSent);
+            outputSerialData(true);
+            petWDT();
+
+            //Receiver metrics
+            systemPrintTimestamp();
+            systemPrintln("    Received");
+            systemPrintTimestamp();
+            systemPrint("        Frames: ");
+            systemPrintln(vc->framesReceived);
+            systemPrintTimestamp();
+            systemPrint("        Messages: ");
+            systemPrintln(vc->messagesReceived);
+            systemPrintTimestamp();
+            systemPrint("        Bad Lengths: ");
+            systemPrintln(vc->badLength);
+            systemPrintTimestamp();
+            systemPrint("        Link Failures: ");
+            systemPrintln(linkFailures);
+            outputSerialData(true);
+            petWDT();
+
+            //ACK Management metrics
+            systemPrintTimestamp();
+            systemPrintln("    ACK Management");
+            systemPrintTimestamp();
+            systemPrint("        Last RX ACK number: ");
+            systemPrintln(vc->rxAckNumber);
+            systemPrintTimestamp();
+            systemPrint("        Next RX ACK number: ");
+            systemPrintln(vc->rmtTxAckNumber);
+            systemPrintTimestamp();
+            systemPrint("        Last TX ACK number: ");
+            systemPrintln(vc->txAckNumber);
+            if (txDestVc == cmdVc)
+            {
+              systemPrintTimestamp();
+              systemPrint("        ackTimer: ");
+              if (ackTimer)
+                systemPrintTimestamp(ackTimer + timestampOffset);
+              else
+                systemPrint("Not Running");
+              systemPrintln();
+            }
           }
         }
         return true;

--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -45,6 +45,9 @@ const int FIRMWARE_VERSION_MINOR = 0;
 #define RADIOLIB_LOW_LEVEL  //Enable access to the module functions
 //#define ENABLE_DEVELOPER true //Uncomment this line to enable special developer modes
 
+#define DEFAULT_AIR_SPEED       4800
+#define DEFAULT_OPERATING_MODE  MODE_POINT_TO_POINT
+
 #define UNUSED(x) (void)(x)
 
 //Define the LoRaSerial board identifier:

--- a/Firmware/LoRaSerial/LoRaSerial.ino
+++ b/Firmware/LoRaSerial/LoRaSerial.ino
@@ -518,7 +518,6 @@ unsigned long retransmitTimeout = 0; //Throttle back re-transmits
 
 //Global variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-const Settings defaultSettings;
 Settings settings; //Active settings used by the radio
 Settings tempSettings; //Temporary settings used for command processing
 Settings trainingSettings; //Settings used for training other radios
@@ -629,6 +628,15 @@ void setup()
   arch.beginBoard(); //Initialize the board specific hardware, and ID platform type
 
   loadSettings(); //Load settings from EEPROM
+
+  //Use the current radio settings if they are already set
+  if (!settings.radioBandwidth)
+  {
+    //Set the initial radio parameters
+    getDefaultSettings(&settings);
+    recordSystemSettings();
+  }
+
   serialOperatingMode = settings.operatingMode;
 
   beginSerial(settings.serialSpeed);

--- a/Firmware/LoRaSerial/NVM.ino
+++ b/Firmware/LoRaSerial/NVM.ino
@@ -3,6 +3,9 @@ void loadSettings()
 {
   arch.eepromBegin();
 
+  //Use the default settings
+  getDefaultSettings(&settings);
+
   //Check to see if EEPROM is blank
   uint32_t testRead = 0;
   if (EEPROM.get(0, testRead) == 0xFFFFFFFF)
@@ -53,6 +56,15 @@ void loadSettings()
   validateSettings(); //Confirm these settings are within regulatory bounds
 
   recordSystemSettings();
+}
+
+//Merge the default settings with the default radio settings
+void getDefaultSettings(Settings * newSettings)
+{
+  const Settings defaultSettings;
+
+  //Set the initial radio parameters
+  *newSettings = defaultSettings;
 }
 
 //Modify defaults for each radio type (915, 868, 433, etc)

--- a/Firmware/LoRaSerial/NVM.ino
+++ b/Firmware/LoRaSerial/NVM.ino
@@ -65,6 +65,7 @@ void getDefaultSettings(Settings * newSettings)
 
   //Set the initial radio parameters
   *newSettings = defaultSettings;
+  validateAirSpeed(newSettings, DEFAULT_AIR_SPEED);
 }
 
 //Modify defaults for each radio type (915, 868, 433, etc)

--- a/Firmware/LoRaSerial/States.ino
+++ b/Firmware/LoRaSerial/States.ino
@@ -1160,6 +1160,8 @@ void updateRadioState()
               //Start and adjust freq hop ISR based on remote's remaining clock
               startChannelTimer();
               channelTimerStart -= settings.maxDwellTime;
+              if (!settings.server)
+                virtualCircuitList[VC_SERVER].firstHeartbeatMillis = millis();
               syncChannelTimer(txSyncClocksUsec, 1);
               triggerEvent(TRIGGER_RX_SYNC_CLOCKS);
 
@@ -1320,6 +1322,8 @@ void updateRadioState()
 
               //Start and adjust freq hop ISR based on remote's remaining clock
               channelTimerStart -= settings.maxDwellTime;
+              if (!settings.server)
+                virtualCircuitList[VC_SERVER].firstHeartbeatMillis = millis();
               syncChannelTimer(txSyncClocksUsec, 1);
 
               if (settings.debugSync)
@@ -1434,6 +1438,9 @@ void updateRadioState()
             //Sync clock if server sent the heartbeat
             if (settings.server == false)
             {
+              if (!settings.server)
+                virtualCircuitList[VC_SERVER].lastTrafficMillis = millis();
+
               //Adjust freq hop ISR based on server's remaining clock
               syncChannelTimer(txHeartbeatUsec, 0);
 
@@ -1495,8 +1502,15 @@ void updateRadioState()
           if ((millis() - lastPacketReceived) > ((uint32_t)settings.heartbeatTimeout * LINK_BREAK_MULTIPLIER))
           {
             if (settings.debugSync)
-            {
               systemPrintln("HEARTBEAT Timeout");
+            if ((!settings.server) && settings.debugHopTimer)
+            {
+              systemPrint("Link Uptime: ");
+              systemPrintln(virtualCircuitList[VC_SERVER].lastTrafficMillis
+                            - virtualCircuitList[VC_SERVER].firstHeartbeatMillis);
+            }
+            if (settings.debugSync || settings.debugHopTimer)
+            {
               outputSerialData(true);
               dumpClockSynchronization();
             }

--- a/Firmware/LoRaSerial/System.ino
+++ b/Firmware/LoRaSerial/System.ino
@@ -1287,6 +1287,11 @@ void verifyTables()
     if (errorMessage)
       break;
 
+    //Verify the airSpeed table
+    errorMessage = verifyAirSpeedTable();
+    if(errorMessage)
+      break;
+
     //Verify the VC state name table
     errorMessage = verifyVcStateNames();
     if (errorMessage)

--- a/Firmware/LoRaSerial/System.ino
+++ b/Firmware/LoRaSerial/System.ino
@@ -985,8 +985,7 @@ void multiPointLeds()
   blinkRadioRssiLed();
 
   //Update the hop LED
-  if ((millis() - radioCallHistory[RADIO_CALL_hopChannel]) >= RADIO_USE_BLINK_MILLIS)
-    digitalWrite(YELLOW_LED, LED_OFF);
+  blinkChannelHopLed(false);
 
   //Update the HEARTBEAT LED
   blinkHeartbeatLed(false);
@@ -1006,8 +1005,7 @@ void p2pLeds()
   //Leave the LINK LED (GREEN_LED_2) off
 
   //Update the hop LED
-  if ((millis() - radioCallHistory[RADIO_CALL_hopChannel]) >= RADIO_USE_BLINK_MILLIS)
-    digitalWrite(YELLOW_LED, LED_OFF);
+  blinkChannelHopLed(false);
 
   //Update the HEARTBEAT LED
   blinkHeartbeatLed(false);
@@ -1049,8 +1047,7 @@ void vcLeds()
   //Serial RX displayed on the LINK LED (GREEN_LED_2) by blinkSerialRxLed
 
   //Update the hop LED
-  if ((millis() - radioCallHistory[RADIO_CALL_hopChannel]) >= RADIO_USE_BLINK_MILLIS)
-    digitalWrite(YELLOW_LED, LED_OFF);
+  blinkChannelHopLed(false);
 
   //Update the HEARTBEAT LED
   blinkHeartbeatLed(false);

--- a/Firmware/LoRaSerial/Train.ino
+++ b/Firmware/LoRaSerial/Train.ino
@@ -101,7 +101,7 @@ void beginTrainingServer()
 void commonTrainingInitialization()
 {
   //Use common radio settings between the client and server for training
-  settings = defaultSettings;
+  getDefaultSettings(&settings);
   settings.dataScrambling = true;           //Scramble the data
   settings.enableCRC16 = true;              //Use CRC-16
   settings.encryptData = true;              //Enable packet encryption

--- a/Firmware/LoRaSerial/settings.h
+++ b/Firmware/LoRaSerial/settings.h
@@ -487,6 +487,7 @@ typedef struct struct_settings {
   bool debug = false; //Print basic events: ie, radio state changes
   bool debugDatagrams = false; //Print the datagrams
   bool debugHeartbeat = false; //Print the HEARTBEAT timing values
+  bool debugHopTimer = false; //Print the hop timer when the link fails
 
   bool debugNvm = false; //Debug NVM operation
   bool debugRadio = false; //Print radio info


### PR DESCRIPTION
Move airSpeed values into a table.
Verify the airSpeed table against the enum values
Load the default values anytime the EEPROM is erased
Add preamble to air speed values
